### PR TITLE
Major refactor to contract UTXO handling

### DIFF
--- a/src/cache.rs
+++ b/src/cache.rs
@@ -1,0 +1,163 @@
+use bitcoin::{
+    TxOut,
+};
+
+use bitcoin::secp256k1::{
+    Secp256k1,
+    Verification,
+};
+
+use std::borrow::{Borrow, Cow};
+use std::cell::RefCell;
+use std::collections::{BTreeMap, HashMap};
+use std::ops::Deref;
+use std::rc::Rc;
+
+use crate::vault::{Depth, GetVaultTemplateError, VaultAmount, VaultGeneration, VaultParameters, VaultStateParameters, VaultTemplates,};
+use crate::transaction::{
+    DepositTransactionTemplate,
+    VaultTransactionTemplate,
+};
+
+pub(crate) struct VaultTemplateCache {
+    parameters: VaultParameters,
+    cache: RefCell<BTreeMap<Depth, CachedVaultGeneration>>,
+}
+
+impl VaultTemplateCache {
+    pub fn new(parameters: VaultParameters) -> Self {
+        Self {
+            parameters,
+            cache: RefCell::new(BTreeMap::new()),
+        }
+    }
+}
+
+#[derive(Clone)]
+pub(crate) struct CachedVaultGeneration(Rc<VaultGeneration>);
+
+impl Deref for CachedVaultGeneration {
+    type Target = VaultGeneration;
+
+    fn deref(&self) -> &Self::Target {
+        self.0.as_ref()
+    }
+}
+
+impl Borrow<VaultGeneration> for CachedVaultGeneration {
+    fn borrow(&self) -> &VaultGeneration {
+        self.0.as_ref()
+    }
+}
+
+impl AsRef<VaultGeneration> for CachedVaultGeneration {
+    fn as_ref(&self) -> &VaultGeneration {
+        self.0.as_ref()
+    }
+}
+
+impl CachedVaultGeneration {
+    fn new(generation: VaultGeneration) -> Self {
+        Self(Rc::new(generation))
+    }
+}
+
+impl VaultTemplates for VaultTemplateCache {
+    type Templates = CachedVaultGeneration;
+
+    fn get<C: Verification>(&self, secp: &Secp256k1<C>, depth: Depth, parameters: &VaultStateParameters) -> Result<VaultTransactionTemplate, GetVaultTemplateError> {
+        let generation = self.get_generation(secp, depth)
+            .ok_or(GetVaultTemplateError::InvalidVaultDepth)?;
+
+        generation.get(parameters).cloned().ok_or(GetVaultTemplateError::InvalidParameters)
+    }
+
+    fn get_generation<C: Verification>(&self, secp: &Secp256k1<C>, depth: Depth) -> Option<Self::Templates> {
+        if depth > self.parameters.max_depth {
+            return None;
+        }
+
+        let new_templates = {
+            let cache = self.cache.borrow();
+            let (cached_depth, templates) = if let Some((cached_depth, templates)) = cache.range(depth..).next() {
+                (*cached_depth, Cow::Borrowed(templates))
+            } else {
+                (
+                    self.parameters.max_depth,
+                    Cow::Owned(
+                        CachedVaultGeneration::new(
+                            self.parameters.tx_templates(secp, self.parameters.max_depth, None)
+                        )
+                    )
+                )
+            };
+
+            if cached_depth == depth {
+                match templates {
+                    Cow::Borrowed(templates) => return Some(templates.clone()),
+                    Cow::Owned(templates) => templates,
+                }
+            } else {
+                let mut current_depth = cached_depth;
+                let mut current_templates = templates;
+
+                while current_depth != depth {
+                    current_depth -= 1;
+
+                    assert!(current_depth >= depth);
+
+                    current_templates = match current_templates {
+                        Cow::Borrowed(templates) => Cow::Owned(
+                            CachedVaultGeneration::new(
+                                self.parameters.tx_templates(secp, current_depth, Some(templates.deref()))
+                            )
+                        ),
+                        Cow::Owned(templates) => Cow::Owned(
+                            CachedVaultGeneration::new(
+                                self.parameters.tx_templates(secp, current_depth, Some(&templates))
+                            )
+                        ),
+                    };
+                }
+
+                current_templates.into_owned()
+            }
+        };
+
+        self.cache.borrow_mut().insert(depth, new_templates);
+
+        self.cache.borrow().get(&depth).cloned()
+    }
+}
+
+pub(crate) struct AddTransactionStateCache {
+    first_generation_spks: HashMap<TxOut, VaultAmount>,
+}
+
+impl AddTransactionStateCache {
+    pub(crate) fn get_initial_deposit_amount(&self, output: &TxOut) -> Option<VaultAmount> {
+        self.first_generation_spks.get(output).cloned()
+    }
+
+    pub(crate) fn new<C: Verification, T: VaultTemplates>(secp: &Secp256k1<C>, templates: &T) -> Self {
+        let first_generation = templates.get_generation(secp, 0)
+            .expect("First generation must exist");
+
+        let first_generation_spks: HashMap<_, _> = first_generation
+            .iter()
+            .filter_map(|(parameters, template)| {
+                match template {
+                    VaultTransactionTemplate::Deposit(DepositTransactionTemplate::InitialDeposit(deposit)) => Some(
+                        (
+                            deposit.vault_output().clone(),
+                            parameters.result_value(),
+                        )
+                    ),
+                    _ => { panic!("Invalid first generation"); }
+                }
+            })
+            .collect();
+
+        Self { first_generation_spks }
+    }
+}

--- a/src/chain.rs
+++ b/src/chain.rs
@@ -1,0 +1,1298 @@
+use bitcoin::{
+    Block,
+    BlockHash,
+    OutPoint,
+    Txid,
+};
+
+use bitcoin::secp256k1::{
+    Secp256k1,
+    Verification,
+};
+
+use std::borrow::Borrow;
+use std::cell::RefCell;
+use std::collections::{HashMap, BTreeSet, BTreeMap, btree_map};
+use std::rc::{Rc, Weak};
+
+fn utxos<T, O>(transaction: Rc<T>) -> impl Iterator<Item = (OutPoint, Rc<T>, O)>
+where
+    T: ContractTransaction + ContractOutputs<OutputMetadata = O>,
+{
+    let txid = transaction.txid();
+
+    transaction
+        .outputs()
+        .into_iter()
+        .map(move |(vout, metadata)|
+            (
+                OutPoint { vout, txid },
+                transaction.clone(),
+                metadata,
+            )
+        )
+}
+
+pub trait ContractInputs {
+    // FIXME: This should be a map shouldn't it?
+    fn inputs(&self) -> BTreeSet<(u32, OutPoint)>;
+}
+
+pub trait ContractOutputs {
+    type OutputMetadata;
+
+    fn outputs(&self) -> BTreeMap<u32, Self::OutputMetadata>;
+}
+
+pub trait ContractTransaction {
+    fn txid(&self) -> Txid;
+}
+
+#[derive(Debug)]
+pub enum ConnectTransactionSuccess<T, O>
+{
+    Connect {
+        inputs: BTreeSet<OutPoint>,
+        transaction: T,
+        outputs: BTreeMap<u32, O>,
+    },
+    Ignore,
+}
+
+impl<T, O> From<T> for ConnectTransactionSuccess<T, O>
+where
+    T: ContractInputs + ContractOutputs<OutputMetadata = O>
+{
+    fn from(transaction: T) -> Self {
+        let inputs = transaction
+            .inputs()
+            .into_iter()
+            .map(|(_input_index, outpoint)| outpoint);
+        let outputs = transaction.outputs();
+
+        ConnectTransactionSuccess::Connect {
+            inputs: inputs.collect(),
+            transaction,
+            outputs,
+        }
+    }
+}
+
+pub trait ContractTransactionConnector {
+    type Transaction;
+    type OutputMetadata;
+    type Error;
+
+    fn connect<C: Verification>(&self, secp: &Secp256k1<C>, utxos: &ChainTipState<Self::Transaction, Self::OutputMetadata>, transaction: &bitcoin::Transaction)
+        -> Result<
+            ConnectTransactionSuccess<Self::Transaction, Self::OutputMetadata>,
+            Self::Error
+        >;
+}
+
+#[derive(Clone, Debug)]
+pub struct SeenBlock<T> {
+    height: u32,
+    block_hash: BlockHash,
+    /// Direct parent block (may be pruned if no relevant transactions are in it)
+    parent_hash: BlockHash,
+    // XXX: Might be worth it to keep a flattened set of all important ancestors in the chain tip,
+    // maybe keep a special data structure for the chain tip?
+    /// Most recent important ancestor (will not be pruned)
+    important_ancestor: Option<Rc<SeenBlock<T>>>,
+
+    transactions: RefCell<BTreeSet<Rc<T>>>,
+}
+
+impl<T> Ord for SeenBlock<T> {
+    fn cmp(&self, other: &Self) -> std::cmp::Ordering {
+        (self.height, self.block_hash).cmp(&(other.height, other.block_hash))
+    }
+}
+
+impl<T> PartialOrd for SeenBlock<T> {
+    fn partial_cmp(&self, other: &Self) -> Option<std::cmp::Ordering> {
+        Some(<SeenBlock<T> as Ord>::cmp(self, other))
+    }
+}
+
+impl<T> PartialEq for SeenBlock<T> {
+    fn eq(&self, other: &Self) -> bool {
+        (self.height, self.block_hash).eq(&(other.height, other.block_hash))
+    }
+}
+
+impl<T> Eq for SeenBlock<T> { }
+
+trait WeakMap<K, V> {
+    fn get_rc<Q: ?Sized>(&self, k: &Q) -> Option<Rc<V>>
+    where
+        K: Borrow<Q>,
+        Q: std::hash::Hash + Eq;
+
+    #[allow(dead_code)]
+    fn prune_invalid(&mut self);
+}
+
+impl<K, V> WeakMap<K, V> for HashMap<K, Weak<V>>
+where
+    K: std::hash::Hash + Eq,
+{
+    fn get_rc<Q: ?Sized>(&self, k: &Q) -> Option<Rc<V>>
+    where
+        K: Borrow<Q>,
+        Q: std::hash::Hash + Eq,
+    {
+        self.get(k).and_then(Weak::upgrade)
+    }
+
+    fn prune_invalid(&mut self) {
+        self.retain(|_, v| v.upgrade().is_some())
+    }
+}
+
+#[derive(Clone)]
+pub struct ChainTipState<T, O> {
+    /// utxo => (tx, outpoint metadata, height)
+    utxos: BTreeMap<OutPoint, (Rc<T>, O, u32)>,
+    /// All (confirmed) vault transactions
+    transactions: HashMap<Txid, (Rc<T>, u32)>,
+}
+
+// TODO: Maybe eliminate the newtype
+struct ChainTips<T, O>(BTreeMap<Rc<SeenBlock<T>>, ChainTipState<T, O>>);
+
+impl<T, O> ChainTips<T, O> {
+    pub fn new() -> Self { Self(BTreeMap::new()) }
+
+    fn longest(&self) -> Option<(Rc<SeenBlock<T>>, &ChainTipState<T, O>)> {
+        self.0.last_key_value()
+            .map(|(k, v)| (k.clone(), v))
+    }
+
+    fn drop(&mut self, minimum_height: u32) {
+        let mut tips_iter = self.0.iter();
+        
+        let first_retained_block = loop {
+            if let Some((tip, _)) = tips_iter.next() {
+                if minimum_height <= tip.height {
+                    break Some(tip.clone());
+                }
+            } else {
+                break None;
+            }
+        };
+
+        if let Some(first_retained_block) = first_retained_block {
+            self.0 = self.0.split_off(&first_retained_block);
+        }
+    }
+
+    fn iter(&self) -> impl Iterator<Item = (&SeenBlock<T>, &ChainTipState<T, O>)> {
+        self.0.iter().rev().map(|(block, state)| (block.as_ref(), state))
+    }
+
+    fn iter_mut(&mut self) -> impl Iterator<Item = (Rc<SeenBlock<T>>, &mut ChainTipState<T, O>)> {
+        self.0.iter_mut().map(|(block, state)| (block.clone(), state))
+    }
+
+    fn get_mut(&mut self, block: &Rc<SeenBlock<T>>) -> Option<&mut ChainTipState<T, O>> {
+        self.0.get_mut(block)
+    }
+}
+
+impl<T, O> ChainTips<T, O>
+where
+    ChainTipState<T, O>: Clone,
+    O: Ord,
+    T: Clone + Ord + ContractTransaction + ContractOutputs<OutputMetadata = O> + ContractInputs,
+{
+    fn add_block(&mut self, parent_block: Option<Rc<SeenBlock<T>>>, block: Rc<SeenBlock<T>>) -> &mut ChainTipState<T, O> {
+        // Couldn't figure out how to satisfy the borrow checker to have a single search in the
+        // vacant case, but it's fine
+        let state =
+            if let Some(parent_block) = parent_block {
+                match self.0.entry(parent_block.clone()) {
+                    btree_map::Entry::Vacant(_) => ChainTipState::new(),
+                    btree_map::Entry::Occupied(entry) => entry.remove(),
+                }
+            } else {
+                ChainTipState::new()
+            };
+
+        self.0.entry(block).or_insert(state)
+    }
+}
+
+#[derive(Clone, Copy, Debug)]
+pub enum UtxoSelector {
+    /// Only select UTXOs confirmed at or before a given height
+    /// If height is None, UTXOs with any confirmation are accepted
+    Confirmed(Option<u32>),
+    /// Implies any height is valid
+    /// bool defines whether it replaces unconfirmed spends or not
+    #[allow(dead_code)]
+    Unconfirmed(bool),
+}
+
+impl UtxoSelector {
+    pub fn any_confirmed() -> Self {
+        Self::Confirmed(None)
+    }
+
+    // FIXME: Struggling to decide what behavior we want generally
+    fn select(&self, height: Option<u32>, unconfirmed_spend: bool) -> bool {
+        match self {
+            // Confirmed on or before max_height
+            Self::Confirmed(Some(max_height)) => match height {
+                Some(height) => height <= *max_height,
+                None => false,
+            }
+            // As long as it's confirmed
+            Self::Confirmed(None) => height.is_some(),
+            // Replace unconfirmed spends
+            Self::Unconfirmed(true) => true,
+            // Don't replace existing unconfirmed spends
+            Self::Unconfirmed(false) => !unconfirmed_spend,
+        }
+    }
+}
+
+#[derive(Debug)]
+pub enum RevertConfirmedTransactionError {
+    /// Trying to revert a transaction with spent outputs
+    /// Indicates its being reverted before a child transaction
+    UtxoSpent,
+    Inconsistent,
+    MissingTxid,
+    MissingInput,
+}
+
+#[derive(Debug)]
+pub enum AddBlockError {
+    IrreconcilableHistory,
+    MissingParent(BlockHash),
+    RevertConfirmedTransactionError(RevertConfirmedTransactionError),
+    AddTransactionError,
+}
+
+impl<T, O> ChainTipState<T, O> {
+    pub fn new() -> Self {
+        Self {
+            utxos: BTreeMap::new(),
+            transactions: HashMap::new(),
+        }
+    }
+
+    pub fn transaction(&self, txid: Txid) -> Option<Rc<T>> {
+        self.transactions.get(&txid).map(|(tx, _height)| tx.clone())
+    }
+
+    pub fn utxo(&self, outpoint: OutPoint) -> Option<(&Rc<T>, &O, u32)> {
+        self.utxos.get(&outpoint)
+            .map(|(tx, metadata, height)| (tx, metadata, *height))
+    }
+}
+
+impl<T, O> ChainTipState<T, O>
+where
+    ChainTipState<T, O>: Clone,
+    O: Ord,
+    T: Clone + Ord + ContractTransaction + ContractInputs + ContractOutputs<OutputMetadata = O>,
+{
+    pub fn rewind_to(&self, current_tip: Rc<SeenBlock<T>>, new_tip: &SeenBlock<T>) -> Result<ChainTipState<T, O>, RevertConfirmedTransactionError> {
+        let mut state = self.clone();
+
+        let blocks = ChainWalker::new(current_tip);
+
+        for block in blocks {
+            if new_tip == block.as_ref() {
+                return Ok(state);
+            }
+
+            for tx in block.transactions.borrow().iter().rev() {
+                let _ = state.revert_confirmed(tx.txid())?;
+            }
+        }
+
+        Err(RevertConfirmedTransactionError::Inconsistent)
+    }
+}
+
+impl<T, O> ChainTipState<T, O>
+where
+    O: Ord,
+    T: Clone + Ord + ContractTransaction + ContractInputs + ContractOutputs<OutputMetadata = O>,
+{
+    pub fn add<C: Verification, Cc>(&mut self, secp: &Secp256k1<C>, connector: &Cc, txid: Txid, transaction: &bitcoin::Transaction, height: u32) -> Result<AddTransactionSuccess<T>, AddTransactionError<Cc::Error>>
+    where
+        Cc: ContractTransactionConnector<Transaction = T, OutputMetadata = O>,
+    {
+        match connector.connect(secp, &self, transaction) {
+            Ok(ConnectTransactionSuccess::Connect { inputs, transaction, outputs }) => {
+                if !inputs.iter().all(|input| self.utxos.contains_key(input)) {
+                    return Err(AddTransactionError::MissingInputs);
+                }
+                let transaction = Rc::new(transaction);
+
+                match self.add_confirmed(txid, inputs, transaction, outputs, height) {
+                    Some(tx) => Ok(AddTransactionSuccess::TransactionAdded(tx)),
+                    None => Err(AddTransactionError::InternalError),
+                }
+            }
+            Ok(ConnectTransactionSuccess::Ignore) =>
+                Ok(AddTransactionSuccess::TransactionIgnored),
+            Err(e) => Err(AddTransactionError::ConnectError(e)),
+        }
+    }
+
+    fn revert_confirmed(&mut self, txid: Txid) -> Result<Rc<T>, RevertConfirmedTransactionError> {
+        let transaction = if let Some((transaction, _height)) = self.transactions.get(&txid) {
+            transaction.clone()
+        } else {
+            return Err(RevertConfirmedTransactionError::MissingTxid);
+        };
+
+        let utxos: BTreeSet<_> = utxos(transaction.clone()).collect();
+
+        let utxos_spent = utxos.iter().any(|(outpoint, ..)| !self.utxos.contains_key(outpoint));
+        if utxos_spent {
+            return Err(RevertConfirmedTransactionError::UtxoSpent);
+        }
+
+        let input_txes: BTreeMap<Txid, (Rc<T>, u32)> = transaction.inputs()
+            .iter()
+            .map(|(_input_index, outpoint)|
+                self.transactions.get(&outpoint.txid)
+                    .map(|(transaction, height)| (outpoint.txid, (transaction.clone(), *height)))
+                    .ok_or(RevertConfirmedTransactionError::MissingInput)
+             )
+            .collect::<Result<_, _>>()?;
+            
+        let input_utxos = input_txes.iter()
+            .flat_map(|(txid, (tx, height))| {
+                tx.outputs()
+                    .into_iter()
+                    .map(|(vout, metadata)| (
+                            OutPoint {
+                                vout,
+                                txid: txid.clone(),
+                            },
+                            (
+                                tx.clone(),
+                                metadata,
+                                *height,
+                            )
+                        )
+                    )
+            });
+
+        self.transactions.remove(&txid);
+        self.utxos.retain(|outpoint, _| outpoint.txid != txid);
+        self.utxos.extend(input_utxos);
+
+        Ok(transaction)
+    }
+
+    pub fn utxos(&self, selector: UtxoSelector) -> BTreeSet<(&OutPoint, Rc<T>, &O, u32)> {
+        self.utxos.iter()
+            .filter(|(_outpoint, (_tx, _output_metadata, height))| selector.select(Some(*height), false))
+            .map(|(outpoint, (tx, output_metadata, height))| (outpoint, tx.clone(), output_metadata, *height))
+            .collect()
+    }
+}
+
+impl<T, O> ChainTipState<T, O>
+{
+    pub fn add_confirmed(&mut self, txid: Txid, inputs: BTreeSet<OutPoint>, transaction: Rc<T>, outputs: BTreeMap<u32, O>, height: u32) -> Option<Rc<T>> {
+        if self.transactions.contains_key(&txid) {
+            return Some(transaction);
+        }
+
+        if inputs.iter().any(|outpoint| !self.utxos.contains_key(outpoint)) {
+            return None;
+        }
+
+        for outpoint in inputs {
+            self.utxos.remove(&outpoint);
+        }
+
+        let utxos = outputs
+            .into_iter()
+            .map(|(vout, output)| (
+                    OutPoint {
+                        txid,
+                        vout,
+                    },
+                    (transaction.clone(), output, height)
+                )
+            );
+
+        self.utxos.extend(utxos);
+        self.transactions.insert(txid, (transaction.clone(), height));
+
+        Some(transaction)
+    }
+}
+
+/// The private add transaction types
+#[derive(Debug, Eq, PartialEq)]
+pub enum AddTransactionSuccess<T> {
+    /// Provided transaction has been added to the vault state
+    TransactionAdded(Rc<T>),
+    /// The provided transaction is irrelevant to this vault
+    TransactionIgnored,
+}
+
+#[derive(Debug, Eq, PartialEq)]
+pub enum AddTransactionError<E> {
+    InternalError,
+    ConnectError(E),
+    MissingInputs,
+}
+
+pub struct ContractState<T, O> {
+    chain_tips: ChainTips<T, O>,
+    blocks: HashMap<BlockHash, Weak<SeenBlock<T>>>,
+    recent_block_cache: BTreeSet<(u32, Rc<SeenBlock<T>>)>,
+}
+
+impl<T, O> ContractState<T, O> {
+    pub fn new() -> Self {
+        Self {
+            chain_tips: ChainTips::new(),
+            blocks: HashMap::new(),
+            recent_block_cache: BTreeSet::new(),
+        }
+    }
+
+    pub fn normalize(&mut self) {
+        const PRUNE_HEIGHT_DELTA: u32 = 144;
+
+        let max_height = self.chain_tips.iter()
+            .map(|(block, _)| block.height)
+            .max()
+            .unwrap_or(0);
+
+        let minimum_height = max_height.checked_sub(PRUNE_HEIGHT_DELTA).unwrap_or(0);
+
+        self.chain_tips.drop(minimum_height);
+        self.blocks.retain(|_, block| block.upgrade().is_some());
+    }
+
+    pub fn longest_chain_tip(&self) -> Option<(Rc<SeenBlock<T>>, &ChainTipState<T, O>)> {
+        self.chain_tips.longest()
+    }
+
+    pub fn get_tip_mut(&mut self, tip: &Rc<SeenBlock<T>>) -> Option<&mut ChainTipState<T, O>> {
+        self.chain_tips.get_mut(tip)
+    }
+}
+
+#[derive(Debug)]
+pub enum ApplyBlockError<E> {
+    AddBlockError(AddBlockError),
+    AddTransactionError(AddTransactionError<E>),
+    InternalError,
+}
+
+impl<T, O> ContractState<T, O>
+where
+    ChainTipState<T, O>: Clone,
+    O: Ord,
+    T: Clone + Ord + ContractTransaction + ContractOutputs<OutputMetadata = O> + ContractInputs,
+    AddTransactionSuccess<T>: std::cmp::PartialEq,
+{
+    pub fn add<C: Verification, Cc>(&mut self, secp: &Secp256k1<C>, connector: &Cc, transaction: &bitcoin::Transaction, height: u32) -> Result<AddTransactionSuccess<T>, AddTransactionError<Cc::Error>>
+    where
+        Cc: ContractTransactionConnector<Transaction = T, OutputMetadata = O>,
+        ChainTipState<T, O>: Clone,
+        O: Ord,
+        T: Ord + ContractOutputs<OutputMetadata = O> + ContractInputs,
+    {
+        let txid = transaction.compute_txid();
+
+        let mut first_success: Option<AddTransactionSuccess<T>> = None;
+        let mut last_error: Option<AddTransactionError<Cc::Error>> = None;
+        for (_tip, state) in self.chain_tips.iter_mut() {
+            match state.add(secp, connector, txid, transaction, height) {
+                Ok(success) => {
+                    if let Some(ref previous_success) = first_success {
+                        if *previous_success != AddTransactionSuccess::TransactionIgnored {
+                        } else {
+                            first_success = Some(success);
+                        }
+                    } else {
+                        first_success = Some(success);
+                    }
+                }
+                Err(e) => { last_error = Some(e); }
+            }
+        }
+
+        match (first_success, last_error) {
+            (Some(AddTransactionSuccess::TransactionIgnored), Some(e)) => Err(e),
+            (Some(success), _) => Ok(success),
+            (_, Some(e)) => Err(e),
+            (_, _) => Err(AddTransactionError::InternalError),
+        }
+    }
+
+    fn rewind_to(&self, height: u32, block_hash: BlockHash) -> Result<(Rc<SeenBlock<T>>, ChainTipState<T, O>), AddBlockError> {
+        'outer: for (tip_block, state) in self.chain_tips.iter()
+            .filter(|(block, _tip)| block.height >= height)
+        {
+            let mut rollback_transactions: Vec<Rc<T>> = Vec::new();
+            
+            let mut tip_block = self.blocks.get_rc(&tip_block.block_hash)
+                .expect("tip block must be in blocks store");
+
+            let mut divergent_block = self.blocks.get_rc(&block_hash)
+                .ok_or(AddBlockError::MissingParent(block_hash))?;
+
+            // Rewind block to height of our diverging block
+            while tip_block.height > divergent_block.height {
+                rollback_transactions.extend(
+                    tip_block.transactions.borrow().iter().rev().cloned()
+                );
+
+                if let Some(block) = self.blocks.get_rc(&tip_block.parent_hash) {
+                    tip_block = block;
+                } else {
+                    continue 'outer;
+                }
+            }
+
+            // rewind divergent block to height of chain tip, this is probably overly defensive
+            // since that should never be necessary
+            while divergent_block.height > tip_block.height {
+                if let Some(block) = self.blocks.get_rc(&divergent_block.parent_hash) {
+                    divergent_block = block;
+                } else {
+                    continue 'outer;
+                }
+            }
+
+            while tip_block != divergent_block {
+                rollback_transactions.extend(
+                    tip_block.transactions.borrow().iter().rev().cloned()
+                );
+
+                if let Some(block) = self.blocks.get_rc(&tip_block.parent_hash) {
+                    tip_block = block;
+                } else {
+                    continue 'outer;
+                }
+
+                if let Some(block) = self.blocks.get_rc(&divergent_block.parent_hash) {
+                    divergent_block = block;
+                } else {
+                    continue 'outer;
+                }
+            }
+
+            let mut new_state = state.clone();
+
+            for transaction in rollback_transactions {
+                new_state.revert_confirmed(transaction.txid())
+                    .expect("rollback transactions should be structured to prevent panic");
+            }
+
+            return Ok((tip_block, new_state))
+        }
+
+        Err(AddBlockError::IrreconcilableHistory)
+    }
+
+    pub fn add_block(&mut self, new_height: u32, new_chain_tip: BlockHash, parent_hash: BlockHash) -> Result<Rc<SeenBlock<T>>, AddBlockError> {
+        if let Some(block) = self.blocks.get_rc(&new_chain_tip) {
+            return Ok(block);
+        }
+
+        let parent = self.blocks
+            .get(&parent_hash)
+            .and_then(|block_ref| block_ref.upgrade());
+
+        let important_ancestor = if let Some(ref parent) = parent {
+            if !parent.transactions.borrow().is_empty() {
+                Some(parent.clone())
+            } else {
+                parent.important_ancestor.clone()
+            }
+        } else {
+            None
+        };
+
+        let block = Rc::new(
+                SeenBlock {
+                    height: new_height,
+                    block_hash: new_chain_tip,
+                    parent_hash,
+                    important_ancestor,
+                    transactions: RefCell::new(BTreeSet::new()),
+                }
+        );
+
+        self.blocks.insert(block.block_hash, Rc::downgrade(&block));
+        self.recent_block_cache.insert((new_height, block.clone()));
+
+        // If the parent isn't a current chain tip we have to do more complicated processing
+        let parent = parent.and_then(|parent| {
+            if self.chain_tips.0.contains_key(&parent) {
+                Some(parent)
+            } else {
+                None
+            }
+        });
+
+        // First block is handled specially
+        let tip_state = if block.height == 1 {
+            self.chain_tips.add_block(None, block.clone())
+        } else if let Some(parent) = parent {
+            self.chain_tips.add_block(Some(parent), block.clone())
+        } else {
+            let parent_height = block.height.saturating_sub(1);
+
+            let (parent, rewound_state) = self.rewind_to(parent_height, block.parent_hash)?;
+
+            let state = self.chain_tips.add_block(Some(parent), block.clone());
+            *state = rewound_state;
+            state
+        };
+
+        for transaction in block.transactions.borrow().iter() {
+            tip_state.add_confirmed(
+                transaction.txid(),
+                transaction.inputs().into_iter().map(|(_, outpoint)| outpoint).collect(),
+                transaction.clone(),
+                transaction.outputs(),
+                block.height,
+            )
+            .ok_or(AddBlockError::AddTransactionError)?;
+        }
+
+        Ok(block)
+    }
+
+    pub fn apply_block<C: Verification, Cc, E>(&mut self, secp: &Secp256k1<C>, connector: &Cc, block: &Block, block_height: u32) -> Result<Vec<Rc<T>>, ApplyBlockError<E>>
+    where
+        Cc: ContractTransactionConnector<Transaction = T, OutputMetadata = O, Error=E>,
+    {
+        let block_hash = block.block_hash();
+        let parent_block_hash = block.header.prev_blockhash;
+
+        let seen_block = self.add_block(block_height, block_hash, parent_block_hash)
+            .map_err(ApplyBlockError::AddBlockError)?;
+
+        let state = self.get_tip_mut(&seen_block)
+            .expect("block was just added");
+
+        let mut added_txes = Vec::new();
+
+        for transaction in &block.txdata {
+            let txid = transaction.compute_txid();
+            let add_result = state.add(secp, connector, txid, transaction, block_height);
+
+            match add_result {
+                Ok(AddTransactionSuccess::TransactionAdded(tx)) => {
+                    seen_block.transactions.borrow_mut()
+                        .insert(tx.clone());
+                    added_txes.push(tx);
+                },
+                Ok(AddTransactionSuccess::TransactionIgnored) => { }
+
+                // TODO: We should revert changes in case of error
+                Err(AddTransactionError::InternalError) => { return Err(ApplyBlockError::InternalError); },
+                Err(AddTransactionError::ConnectError(e)) => {
+                    return Err(
+                        ApplyBlockError::AddTransactionError(
+                            AddTransactionError::ConnectError(e)
+                        )
+                    );
+                }
+                Err(AddTransactionError::MissingInputs) => { return Err(ApplyBlockError::InternalError); }
+            }
+        }
+
+        self.normalize();
+
+        Ok(added_txes)
+    }
+
+    pub fn drop(&mut self, minimum_height: u32) {
+        while let Some((height, _)) = self.recent_block_cache.first() {
+            if *height >= minimum_height {
+                break;
+            }
+
+            self.recent_block_cache.pop_first()
+                .expect("in the loop body recent_block_cache is not empty");
+        }
+
+        self.chain_tips.drop(minimum_height);
+        self.normalize();
+    }
+}
+
+/// Iterate over the important blocks in a chain, from newest to oldest
+// TODO: I think we might be able to do wthis without taking an Rc?
+struct ChainWalker<T> {
+    current_block: Option<Rc<SeenBlock<T>>>,
+}
+
+impl<T> ChainWalker<T> {
+    pub fn new(block: Rc<SeenBlock<T>>) -> Self {
+        Self { current_block: Some(block) }
+    }
+}
+
+impl<T> Iterator for ChainWalker<T> {
+    type Item = Rc<SeenBlock<T>>;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        let current = self.current_block.clone()?;
+
+        self.current_block = current.important_ancestor.clone();
+
+        Some(current)
+    }
+}
+
+pub(crate) enum Either<A, B> {
+    A(A),
+    B(B),
+}
+
+impl<A, B, I> Iterator for Either<A, B>
+where
+    A: Iterator<Item = I>,
+    B: Iterator<Item = I>,
+{
+    type Item = I;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        match self {
+            Self::A(ref mut a) => a.next(),
+            Self::B(ref mut b) => b.next(),
+        }
+    }
+}
+
+#[cfg(test)]
+mod test {
+    // XXX: We abuse the fact there's very little/no validation of blocks and transactions in
+    // rust-bitcoin to construct these pseudo-mocks.
+
+    use super::*;
+
+    use bitcoin::{
+        Amount,
+        block,
+        CompactTarget,
+        locktime::absolute,
+        Transaction,
+        TxIn,
+        TxOut,
+        transaction,
+        ScriptBuf,
+        Sequence,
+        Witness,
+    };
+
+    use bitcoin::bip32::{
+        Xpriv,
+        Xpub,
+        ChildNumber,
+    };
+
+    use bitcoin::hashes::Hash;
+
+    use bitcoin::secp256k1::{
+        Signing,
+        XOnlyPublicKey,
+    };
+
+    use std::iter;
+    use std::str::FromStr;
+
+    #[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord)]
+    enum TransactionType {
+        Head,
+        Body(u32),
+        Tail(u32),
+    }
+
+    impl TransactionType {
+        fn to_pk_index(&self) -> u32 {
+            match self {
+                TransactionType::Head => 0,
+                TransactionType::Body(i) => *i,
+                TransactionType::Tail(i) => *i,
+            }
+        }
+    }
+
+    #[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord)]
+    struct ContractOutput;
+
+    #[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord)]
+    struct TestContractTransaction {
+        txid: Txid,
+        transaction: Transaction,
+        txtype: TransactionType,
+        pubkey: XOnlyPublicKey,
+    }
+
+    impl ContractInputs for TestContractTransaction {
+        fn inputs(&self) -> BTreeSet<(u32, OutPoint)> {
+            match self.txtype {
+                TransactionType::Head => iter::empty().collect(),
+                _ => self.transaction.input.iter()
+                    .enumerate()
+                    .map(|(i, input)| (
+                        i as u32,
+                        input.previous_output,
+                    ))
+                    .collect(),
+            }
+        }
+    }
+
+    impl ContractOutputs for TestContractTransaction {
+        type OutputMetadata = ContractOutput;
+
+        fn outputs(&self) -> BTreeMap<u32, Self::OutputMetadata> {
+            match self.txtype {
+                TransactionType::Tail(_) => iter::empty().collect(),
+                _ => iter::once((0, ContractOutput)).collect(),
+            }
+        }
+    }
+
+    impl ContractTransaction for TestContractTransaction {
+        fn txid(&self) -> Txid { self.txid }
+    }
+
+    struct TestContractContext(Xpub, u32);
+
+    impl TestContractContext {
+        fn pubkey<C: Verification>(&self, secp: &Secp256k1<C>, index: u32) -> XOnlyPublicKey {
+            self.0.derive_pub(secp, &[
+                    ChildNumber::from_normal_idx(index)
+                        .expect("test indices will be constrained")
+                ]
+            )
+            .expect("valid")
+            .to_x_only_pub()
+        }
+
+        fn initial<C: Verification>(&self, secp: &Secp256k1<C>, outpoint: OutPoint) -> TestContractTransaction {
+            let pubkey = self.pubkey(secp, 0);
+
+            let transaction = Transaction {
+                version: transaction::Version::TWO,
+                lock_time: absolute::LockTime::ZERO,
+                input: vec![
+                    TxIn {
+                        previous_output: outpoint,
+                        script_sig: ScriptBuf::new(),
+                        sequence: Sequence::MAX,
+                        witness: Witness::new(),
+                    },
+                ],
+                output: vec![
+                    TxOut {
+                        value: Amount::ONE_BTC,
+                        script_pubkey: ScriptBuf::new_p2tr(secp, pubkey, None),
+                    },
+                ],
+            };
+
+            TestContractTransaction {
+                txid: transaction.compute_txid(),
+                transaction,
+                txtype: TransactionType::Head,
+                pubkey,
+            }
+        }
+    }
+
+    struct TestContract {
+        context: TestContractContext,
+        state: ContractState<TestContractTransaction, ContractOutput>,
+    }
+
+    impl TestContract {
+        fn initial<C: Verification>(&self, secp: &Secp256k1<C>, outpoint: OutPoint) -> TestContractTransaction {
+            self.context.initial(secp, outpoint)
+        }
+
+        fn next<C: Verification>(&self, secp: &Secp256k1<C>, previous: &TestContractTransaction) -> Option<TestContractTransaction> {
+            let txtype = match previous.txtype {
+                TransactionType::Head => TransactionType::Body(1),
+                TransactionType::Body(i) if (i + 1) < self.context.1 => TransactionType::Body(i + 1),
+                TransactionType::Body(i) => TransactionType::Tail(i + 1),
+                TransactionType::Tail(_) => { return None; }
+            };
+
+            let pk_index = txtype.to_pk_index();
+            let pubkey = self.context.pubkey(secp, pk_index);
+
+            let transaction = Transaction {
+                version: transaction::Version::TWO,
+                lock_time: absolute::LockTime::ZERO,
+                input: vec![
+                    TxIn {
+                        previous_output: OutPoint {
+                            txid: previous.txid(),
+                            vout: 0,
+                        },
+                        script_sig: ScriptBuf::new(),
+                        sequence: Sequence::MAX,
+                        witness: Witness::new(),
+                    },
+                ],
+                output: vec![
+                    TxOut {
+                        value: Amount::ONE_BTC,
+                        script_pubkey: ScriptBuf::new_p2tr(secp, pubkey, None),
+                    },
+                ],
+            };
+
+            Some(
+                TestContractTransaction {
+                    txid: transaction.compute_txid(),
+                    transaction,
+                    txtype,
+                    pubkey,
+                }
+            )
+        }
+    }
+
+    impl ContractTransactionConnector for TestContractContext {
+        type Transaction = TestContractTransaction;
+
+        type OutputMetadata = ContractOutput;
+
+        type Error = ();
+
+        fn connect<C: Verification>(&self, secp: &Secp256k1<C>, utxos: &ChainTipState<Self::Transaction, Self::OutputMetadata>, transaction: &bitcoin::Transaction)
+            -> Result<
+                ConnectTransactionSuccess<Self::Transaction, Self::OutputMetadata>,
+                Self::Error
+            >
+        {
+            if transaction.input.len() != 1 {
+                return Ok(ConnectTransactionSuccess::Ignore);
+            }
+
+            let outpoint = transaction.input[0].previous_output;
+
+            let prev_tx = match utxos.utxo(outpoint) {
+                Some((prev_tx, _metadata, _height)) => prev_tx,
+                None => {
+                    if transaction.output.len() != 1 {
+                        return Ok(ConnectTransactionSuccess::Ignore);
+                    }
+
+                    let first_pk = self.pubkey(secp, 0);
+                    let first_spk = ScriptBuf::new_p2tr(secp, first_pk, None);
+
+                    if transaction.output[0].script_pubkey == first_spk {
+                        let transaction = TestContractTransaction {
+                            txid: transaction.compute_txid(),
+                            transaction: transaction.clone(),
+                            txtype: TransactionType::Head,
+                            pubkey: first_pk,
+                        };
+
+                        return Ok(transaction.into());
+                    }
+
+                    return Ok(ConnectTransactionSuccess::Ignore);
+                }
+            };
+
+            let max_index = self.1;
+
+            let txtype = match prev_tx.txtype {
+                TransactionType::Head => TransactionType::Body(1),
+                TransactionType::Body(i) if (i + 1) < max_index => TransactionType::Body(i + 1),
+                TransactionType::Body(i) => TransactionType::Tail(i + 1),
+                TransactionType::Tail(_) => {
+                    return Ok(ConnectTransactionSuccess::Ignore);
+                }
+            };
+
+            let pk_index = txtype.to_pk_index();
+
+            let pubkey = self.pubkey(secp, pk_index);
+            
+            let transaction = TestContractTransaction {
+                txid: transaction.compute_txid(),
+                transaction: transaction.clone(),
+                txtype,
+                pubkey,
+            };
+
+            Ok(transaction.into())
+        }
+    }
+
+    struct ContractId(u32);
+
+    fn make_test_contract<C: Signing>(secp: &Secp256k1<C>, contract_id: ContractId) -> (Xpriv, TestContract) {
+        let milk_sad_master = Xpriv::from_str("tprv8ZgxMBicQKsPd1EzCPZcQSPhsotX5HvRDCivA7ASNQFmjWuTsW3WWEwUNKFAZrnD9qpz55rtyLdphqkwRZUqNWYXwSEzd6P4pYvXGByRim3").unwrap();
+
+        let master = milk_sad_master.derive_priv(secp, &[
+            ChildNumber::from_hardened_idx(contract_id.0).expect("valid contract id")
+        ])
+        .expect("sane test values");
+
+        let xpub = Xpub::from_priv(secp, &master);
+
+        (
+            master,
+            TestContract {
+                context: TestContractContext(xpub, 3),
+                state: ContractState::new(),
+            }
+        )
+    }
+
+    fn make_test_genesis() -> Block {
+        Block {
+            header: block::Header {
+                version: block::Version::ONE,
+                prev_blockhash: BlockHash::from_byte_array([0; 32]),
+                merkle_root: block::TxMerkleNode::from_byte_array([0; 32]),
+                time: 0,
+                bits: CompactTarget::default(),
+                nonce: 0,
+            },
+            txdata: vec![],
+        }
+    }
+
+    fn make_test_block_inner(previous: BlockHash, nonce: u32, txdata: Vec<Transaction>) -> Block {
+        let mut initial_block = Block {
+            header: block::Header {
+                version: block::Version::ONE,
+                prev_blockhash: previous,
+                merkle_root: block::TxMerkleNode::from_byte_array([0; 32]),
+                time: 0,
+                bits: CompactTarget::default(),
+                nonce,
+            },
+            txdata,
+        };
+
+        if let Some(merkle_root) = initial_block.compute_merkle_root() {
+            initial_block.header.merkle_root = merkle_root;
+        }
+
+        initial_block
+    }
+
+    fn make_test_block(previous: &Block, nonce: u32, txdata: Vec<Transaction>) -> Block {
+        make_test_block_inner(previous.block_hash(), nonce, txdata)
+    }
+
+    fn make_test_prevout(seed: u64) -> OutPoint {
+        const MAX_VOUT: u64 = 252;
+        let seed_bytes = seed.to_be_bytes();
+        let mut txid = [0u8; 32];
+        for i in 0..4 {
+            txid[(i * 8)..((i + 1) * 8)].copy_from_slice(&seed_bytes);
+        }
+
+        OutPoint {
+            txid: Txid::from_byte_array(txid),
+            vout: (seed % (MAX_VOUT + 1)) as u32,
+        }
+    }
+
+    fn make_test_seen_genesis() -> (Block, Rc<SeenBlock<TestContractTransaction>>) {
+        let genesis = make_test_genesis();
+        let block0 = Rc::new(SeenBlock {
+            height: 0,
+            block_hash: genesis.block_hash(),
+            parent_hash: genesis.block_hash(), // Doesn't matter
+            important_ancestor: None,
+            transactions: RefCell::new(BTreeSet::new()),
+        });
+
+        (genesis, block0)
+    }
+    /// Helper that creates a child
+    fn make_test_child_block(
+        parent: &Rc<SeenBlock<TestContractTransaction>>,
+        important_ancestor: Option<Rc<SeenBlock<TestContractTransaction>>>,
+        transactions: Vec<TestContractTransaction>,
+    ) -> Rc<SeenBlock<TestContractTransaction>> {
+        let next = make_test_block_inner(parent.block_hash, 0, vec![]);
+
+        Rc::new(
+            SeenBlock {
+                height: parent.height,
+                block_hash: next.block_hash(),
+                parent_hash: parent.block_hash,
+                important_ancestor,
+                transactions: RefCell::new(transactions.into_iter().map(Rc::new).collect()),
+            }
+        )
+    }
+
+    #[test]
+    fn test_chain_single_tip() {
+        let mut tips: ChainTips<TestContractTransaction, ContractOutput> = ChainTips::new();
+
+        let (_genesis, block0) = make_test_seen_genesis();
+        let block1 = make_test_child_block(&block0, None, vec![]);
+        let block2 = make_test_child_block(&block1, None, vec![]);
+
+        tips.add_block(None, block0.clone());
+        assert_eq!(tips.0.len(), 1);
+        tips.add_block(Some(block0.clone()), block1.clone());
+        assert_eq!(tips.0.len(), 1);
+        tips.add_block(Some(block1.clone()), block2.clone());
+        assert_eq!(tips.0.len(), 1);
+    }
+
+    /// Test a chain split
+    #[test]
+    fn test_chain_tips_split() {
+        fn tx_utxos(tx: &TestContractTransaction, height: u32) -> BTreeSet<(OutPoint, ContractOutput, u32)> {
+            tx
+                .outputs()
+                .into_iter()
+                .map(|(vout, metadata)|
+                    (
+                        OutPoint {
+                            txid: tx.txid,
+                            vout,
+                        },
+                        metadata,
+                        height,
+                    )
+                )
+                .collect()
+        }
+
+        fn massage_utxos(state: &ChainTipState<TestContractTransaction, ContractOutput>) -> BTreeSet<(OutPoint, ContractOutput, u32)> {
+            state
+            .utxos(
+                UtxoSelector::any_confirmed()
+            )
+            .into_iter()
+            .map(|(outpoint, _tx, metadata, height)| (outpoint.clone(), metadata.clone(), height))
+            .collect()
+        }
+
+        fn get_utxos(state: &ContractState<TestContractTransaction, ContractOutput>) -> BTreeSet<(OutPoint, ContractOutput, u32)> {
+            let state = state.longest_chain_tip().unwrap().1;
+            massage_utxos(&state)
+        }
+
+        let secp = Secp256k1::new();
+
+        let mut state: ContractState<TestContractTransaction, ContractOutput> = ContractState::new();
+
+        let (_xpriv, contract) = make_test_contract(&secp, ContractId(0));
+
+        let test_tx1 = contract.initial(&secp, make_test_prevout(0));
+        let test_tx2 = contract.initial(&secp, make_test_prevout(1));
+        let test_tx3 = contract.next(&secp, &test_tx1).unwrap();
+
+        let tx1_utxos = tx_utxos(&test_tx1, 1);
+        let tx2_utxos = tx_utxos(&test_tx2, 2);
+        let tx3_utxos = tx_utxos(&test_tx3, 3);
+
+        let genesis = make_test_genesis();
+        let block1 = make_test_block(&genesis, 0, vec![test_tx1.transaction.clone()]);
+        let block2 = make_test_block(&block1, 0, vec![test_tx2.transaction.clone()]);
+
+        let block2b = make_test_block(&block1, 1, vec![]);
+
+        let block3 = make_test_block(&block2b, 0, vec![test_tx3.transaction.clone()]);
+
+        assert_eq!(state.chain_tips.0.len(), 0);
+
+        state.apply_block(&secp, &contract.context, &block1, 1).unwrap();
+        let seen_block1 = state.blocks.get_rc(&block1.block_hash()).unwrap();
+        let utxos = get_utxos(&state);
+        assert!(state.chain_tips.0.contains_key(&seen_block1));
+        assert_eq!(utxos, tx1_utxos);
+        assert_eq!(state.chain_tips.0.len(), 1);
+
+        state.apply_block(&secp, &contract.context, &block2, 2).unwrap();
+        let seen_block2 = state.blocks.get_rc(&block2.block_hash()).unwrap();
+        assert!(!state.chain_tips.0.contains_key(&seen_block1));
+        assert!(state.chain_tips.0.contains_key(&seen_block2));
+        let block2_utxos = get_utxos(&state);
+        let expected_block2_utxos: BTreeSet<_> = tx1_utxos.union(&tx2_utxos).cloned().collect();
+        assert_eq!(block2_utxos, expected_block2_utxos);
+        assert_eq!(state.chain_tips.0.len(), 1);
+
+        state.apply_block(&secp, &contract.context, &block2b, 2).unwrap();
+        let seen_block2b = state.blocks.get_rc(&block2b.block_hash()).unwrap();
+        assert!(!state.chain_tips.0.contains_key(&seen_block1));
+        assert!(state.chain_tips.0.contains_key(&seen_block2));
+        assert!(state.chain_tips.0.contains_key(&seen_block2b));
+        assert_eq!(state.chain_tips.0.len(), 2);
+
+        let block2_utxos = massage_utxos(state.chain_tips.0.get(&seen_block2).unwrap());
+        let block2b_utxos = massage_utxos(state.chain_tips.0.get(&seen_block2b).unwrap());
+        let expected_block2b_utxos = tx1_utxos.clone();
+        assert_eq!(block2_utxos, expected_block2_utxos);
+        assert_eq!(block2b_utxos, expected_block2b_utxos);
+
+        state.apply_block(&secp, &contract.context, &block3, 3).unwrap();
+        let seen_block3 = state.blocks.get_rc(&block3.block_hash()).unwrap();
+        assert!(!state.chain_tips.0.contains_key(&seen_block1));
+        assert!(!state.chain_tips.0.contains_key(&seen_block2b));
+
+        assert!(state.chain_tips.0.contains_key(&seen_block2));
+        assert!(state.chain_tips.0.contains_key(&seen_block3));
+        assert_eq!(state.chain_tips.0.len(), 2);
+
+        let block3_utxos = get_utxos(&state);
+        let expected_block3_utxos = tx3_utxos.clone();
+        assert_eq!(block3_utxos, expected_block3_utxos);
+    }
+
+    fn as_refs<'a, T>(xs: &'a Vec<Rc<T>>) -> Vec<&'a T> {
+        xs.iter().map(|x| x.as_ref()).collect()
+    }
+
+    #[test]
+    fn test_ignore() {
+        let secp = Secp256k1::new();
+        let (_xpriv, mut contract) = make_test_contract(&secp, ContractId(0));
+        let (_xpriv2, mut contract2) = make_test_contract(&secp, ContractId(1));
+
+        let genesis = make_test_genesis();
+        let block1 = make_test_block(&genesis, 0, vec![]);
+
+        let txes = contract.state.apply_block(&secp, &contract.context, &block1, 1)
+            .unwrap();
+        assert_eq!(txes, vec![]);
+
+        let txes = contract2.state.apply_block(&secp, &contract2.context, &block1, 1)
+            .unwrap();
+        assert_eq!(txes, vec![]);
+
+        let contract2_tx1 = contract2.initial(&secp, make_test_prevout(0));
+        let block2 = make_test_block(&block1, 0, vec![contract2_tx1.transaction.clone()]);
+
+        let txes = contract.state.apply_block(&secp, &contract.context, &block2, 2)
+            .unwrap();
+        assert_eq!(txes, vec![]);
+
+        let txes = contract2.state.apply_block(&secp, &contract2.context, &block2, 2)
+            .unwrap();
+        assert_eq!(as_refs(&txes), vec![&contract2_tx1]);
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,5 +1,9 @@
 pub mod bip119;
+pub mod cache;
+mod chain;
 mod migrate;
+pub mod storage;
+mod transaction;
 pub mod vault;
 pub mod wallet;
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -36,6 +36,7 @@ use rand::{
     thread_rng,
 };
 
+#[allow(unused_imports)]
 use rusqlite::{
     Connection,
     params,
@@ -48,6 +49,7 @@ use serde::{
 
 use std::path::PathBuf;
 
+#[allow(unused_imports)]
 use mccv::{
     AccountId,
     VaultAmount,
@@ -57,11 +59,10 @@ use mccv::{
     Vault,
 };
 
-use mccv::vault::{
-    SqliteVaultStorage,
+use mccv::storage::{
+    SqliteStorage,
+    VaultStorage,
 };
-
-const DEFAULT_VAULT: VaultId = 0;
 
 fn new_xpriv(network: NetworkKind) -> Xpriv {
     let mut rng = thread_rng();
@@ -71,6 +72,11 @@ fn new_xpriv(network: NetworkKind) -> Xpriv {
     rng.fill_bytes(&mut seed);
     Xpriv::new_master(network, &seed)
         .expect("privkey generation")
+}
+
+#[derive(Clone, Args)]
+struct GenerateArg {
+    name: String,
 }
 
 #[derive(Clone, Args)]
@@ -87,7 +93,7 @@ struct WithdrawArg {
 
 #[derive(Clone, Subcommand)]
 enum Command {
-    Generate,
+    Generate(GenerateArg),
     List,
     Receive,
     Sync,
@@ -98,6 +104,9 @@ enum Command {
 #[derive(Parser)]
 #[command(name = "mccv")]
 struct CommandLine {
+    #[arg(short = 'v', long = "vault")]
+    vault_id: Option<u64>,
+
     #[arg(short = 'c', long = "config", default_value="./config.toml")]
     config: PathBuf,
 
@@ -137,7 +146,7 @@ fn main() {
     let secp = Secp256k1::new();
 
     match args.command {
-        Command::Generate => {
+        Command::Generate(generate_arg) => {
             let master_xpriv = new_xpriv(args.network.into());
             let account = AccountId::new(0)
                 .expect("account id < 0x7FFFFFFF");
@@ -196,9 +205,12 @@ fn main() {
             wallet.persist(&mut sqlite)
                 .expect("update sqlite");
 
-            let mut storage = SqliteVaultStorage::from_connection(sqlite)
+            let mut storage = SqliteStorage::from_connection(sqlite)
                 .expect("initialize vault storage");
 
+            let (vault, changelog) = storage.create_vault(&generate_arg.name, vault_parameters)
+                .expect("vault creation success");
+            /*
             let vault = Vault::create_new(&mut storage, "Default Vault", vault_parameters.clone()).expect("vault create");
 
             let config = Configuration {
@@ -230,6 +242,7 @@ fn main() {
 
             let config = toml::to_string(&config).expect("serialize config");
             std::fs::write(args.config, config.as_bytes()).expect("write config");
+            */
         },
         Command::List => {
             let config = read_config(&args.config);
@@ -265,9 +278,9 @@ fn main() {
             println!("----------------------------------");
             println!("total: {}", balance.total());
 
-            let mut storage = SqliteVaultStorage::from_connection(sqlite)
+            let mut storage = SqliteStorage::from_connection(sqlite)
                 .expect("initialize vault storage");
-            let vault = Vault::load(DEFAULT_VAULT, &mut storage).expect("load vault");
+            //let vault = Vault::load(DEFAULT_VAULT, &mut storage).expect("load vault");
             todo!()
         }
         Command::Sync => {
@@ -297,9 +310,9 @@ fn main() {
             wallet.persist(&mut sqlite)
                 .expect("update sqlite");
 
-            let mut storage = SqliteVaultStorage::from_connection(sqlite)
+            let mut storage = SqliteStorage::from_connection(sqlite)
                 .expect("initialize vault storage");
-            let vault = Vault::load(DEFAULT_VAULT, &mut storage).expect("load vault");
+            //let vault = Vault::load(DEFAULT_VAULT, &mut storage).expect("load vault");
 
             println!("Sync'd");
         }
@@ -317,9 +330,9 @@ fn main() {
 
             wallet.persist(&mut sqlite).expect("sqlite sync");
 
-            let mut storage = SqliteVaultStorage::from_connection(sqlite)
+            let mut storage = SqliteStorage::from_connection(sqlite)
                 .expect("initialize vault storage");
-            let vault = Vault::load(DEFAULT_VAULT, &mut storage).expect("load vault");
+            //let vault = Vault::load(DEFAULT_VAULT, &mut storage).expect("load vault");
 
             println!("Address: {}", address.to_string());
         }
@@ -346,10 +359,10 @@ fn main() {
                 .load_wallet(&mut sqlite)
                 .expect("success");
 
-            let mut storage = SqliteVaultStorage::from_connection(sqlite)
+            let mut storage = SqliteStorage::from_connection(sqlite)
                 .expect("initialize vault storage");
 
-            let vault = Vault::load(DEFAULT_VAULT, &mut storage).expect("load vault");
+            //let vault = Vault::load(DEFAULT_VAULT, &mut storage).expect("load vault");
 
             todo!()
         }

--- a/src/migrate.rs
+++ b/src/migrate.rs
@@ -1,13 +1,13 @@
 use rusqlite::{
-    Connection,
+    Transaction,
     params,
 };
 
-pub fn configure(connection: &Connection) -> Result<(), rusqlite::Error> {
-    connection.pragma_update(None, "foreign_keys", 1)
-}
+#[allow(dead_code)]
+pub static VAULT_VERSION_ID: i64 = 1;
 
-static MIGRATIONS: [(u32, &str); 1] = [
+#[allow(dead_code)]
+pub static VAULT_MIGRATIONS: [(u32, &str); 1] = [
     (1, include_str!("../data/migrations/0001-initial.sql")),
 ];
 
@@ -18,35 +18,37 @@ pub enum MigrationError {
     FinalizationFailed(rusqlite::Error),
 }
 
-fn get_and_clear_migration_version(connection: &mut Connection) -> Result<(rusqlite::Transaction<'_>, u32), rusqlite::Error> {
-    connection.execute(r#"
+#[allow(dead_code)]
+fn get_and_clear_migration_version(transaction: &mut Transaction<'_>, id: i64) -> Result<u32, rusqlite::Error> {
+    transaction.execute(r#"
         create table
             if not exists
             mccv_migration_version
         (
+            id integer,
             version integer
         )
     "#, [])?;
 
-    let transaction = connection.transaction()?;
-
     let version: u32 = transaction
-        .prepare(r#"select version from mccv_migration_version"#)?
-        .query_map([], |row| row.get(0))?
-        .next().unwrap_or(Ok(0))?;
+        .prepare(r#"select version from mccv_migration_version where id = ?"#)?
+        .query_map(params![id], |row| row.get(0))?
+        .next()
+        .unwrap_or(Ok(0))?;
 
-    transaction.execute(r#"delete from mccv_migration_version"#, [])?;
+    transaction.execute(r#"delete from mccv_migration_version where id = ?"#, params![id])?;
 
-    Ok((transaction, version))
+    Ok(version)
 }
 
-pub fn migrate(connection: &mut Connection) -> Result<(u32, u32), MigrationError> {
-    let (transaction, mut version) = get_and_clear_migration_version(connection)
+#[allow(dead_code)]
+pub fn migrate(transaction: &mut Transaction<'_>, id: i64, migrations: &[(u32, &str)]) -> Result<(u32, u32), MigrationError> {
+    let mut version = get_and_clear_migration_version(transaction, id)
         .map_err(|e| MigrationError::InitializationFailed(e))?;
 
     let initial_version = version;
 
-    for (migration_version, script) in MIGRATIONS.iter() {
+    for (migration_version, script) in migrations.iter() {
         let migration_version = *migration_version;
         if migration_version > version {
             transaction.execute_batch(script)
@@ -55,11 +57,8 @@ pub fn migrate(connection: &mut Connection) -> Result<(u32, u32), MigrationError
         }
     }
 
-    transaction.execute(r#"insert into mccv_migration_version (version) values (?)"#, params![version])
-        .map_err(|e| MigrationError::FinalizationFailed(e))?;
-
-    transaction.commit()
-        .map_err(|e| MigrationError::FinalizationFailed(e))?;
+    transaction.execute(r#"insert into mccv_migration_version (version, id) values (?, ?)"#, params![version, id])
+        .map_err(MigrationError::FinalizationFailed)?;
 
     Ok((initial_version, version))
 }

--- a/src/storage.rs
+++ b/src/storage.rs
@@ -1,0 +1,200 @@
+use bitcoin::{
+    BlockHash,
+    Txid,
+};
+
+use rusqlite;
+
+use crate::vault::{
+    VaultStateTransaction,
+};
+
+use std::ops::{Deref, DerefMut};
+use std::rc::Rc;
+
+use crate::migrate::{
+    MigrationError,
+};
+
+use crate::{
+    Vault,
+    VaultId,
+    VaultParameters,
+};
+
+pub struct SqliteStorage {
+    sqlite: rusqlite::Connection,
+}
+
+#[derive(Debug)]
+pub enum SqliteInitializationError {
+    MigrationError(MigrationError),
+    ConnectionConfigurationError(rusqlite::Error),
+}
+
+#[allow(dead_code)]
+impl SqliteStorage {
+    pub fn from_connection(mut _sqlite: rusqlite::Connection) -> Result<Self, SqliteInitializationError> {
+        todo!()
+    }
+
+    fn store_change(_transaction: &mut rusqlite::Transaction, _vault_id: VaultId, _change: &Change) -> Result<(), StoreError> {
+        todo!()
+    }
+}
+
+impl Deref for SqliteStorage {
+    type Target = rusqlite::Connection;
+
+    fn deref(&self) -> &Self::Target {
+        &self.sqlite
+    }
+}
+
+impl DerefMut for SqliteStorage {
+    fn deref_mut(&mut self) -> &mut Self::Target {
+        &mut self.sqlite
+    }
+}
+
+#[derive(Debug)]
+pub enum StoreError {
+    SqliteError(rusqlite::Error),
+    InvalidState,
+    InternalError,
+}
+
+#[derive(Debug)]
+pub enum LoadError {
+    SqliteError(rusqlite::Error),
+    InvalidState,
+    InternalError,
+    NotFound,
+    InvalidXpub,
+    InvalidWithdrawal,
+    InvalidDeposit,
+}
+
+impl From<rusqlite::Error> for LoadError {
+    fn from(e: rusqlite::Error) -> Self {
+        LoadError::SqliteError(e)
+    }
+}
+
+impl From<rusqlite::types::FromSqlError> for LoadError {
+    fn from(e: rusqlite::types::FromSqlError) -> Self {
+        LoadError::SqliteError(e.into())
+    }
+}
+
+impl std::fmt::Display for LoadError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            LoadError::SqliteError(e) => e.fmt(f),
+            LoadError::InvalidState => write!(f, "Invalid state"),
+            LoadError::InternalError => write!(f, "Internal error"),
+            LoadError::NotFound => write!(f, "Not found"),
+            LoadError::InvalidXpub => write!(f, "Invalid xpub"),
+            LoadError::InvalidWithdrawal => write!(f, "Invalid withdrawal"),
+            LoadError::InvalidDeposit => write!(f, "Invalid deposit"),
+
+        }
+    }
+}
+
+impl std::error::Error for LoadError {
+    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
+        match self {
+            LoadError::SqliteError(e) => Some(e),
+            _ => None,
+        }
+    }
+
+    fn description(&self) -> &str {
+        "Error loading vault data"
+    }
+}
+
+impl From<rusqlite::Error> for StoreError {
+    fn from(e: rusqlite::Error) -> Self {
+        StoreError::SqliteError(e)
+    }
+}
+
+#[derive(Clone,Debug)]
+#[allow(dead_code)]
+pub(crate) enum Change {
+    /// Informs the storage backend or VaultState about the existence of a transaction
+    AddTransaction(Rc<VaultStateTransaction>),
+
+    /// Informs the storage backend or VaultState about the existence of a block, presumably a relevant one
+    AddBlock {
+        height: u32,
+        block_hash: BlockHash,
+        parent_block_hash: BlockHash,
+    },
+
+    /// Informs the storage backend or VaultState of a transaction's inclusion in a given block
+    /// Must be issued after AddTransaction and AddBlock for the provided blocks
+    // FIXME: Lose the height from this? Backend and now VaultState can derive height 
+    Confirm(Txid, BlockHash, u32),
+
+    /// Instructs the storage backend to drop metadata related to the given block
+    Unconfirm(BlockHash),
+}
+
+pub struct ChangeLog {
+    id: VaultId,
+    changes: Vec<Change>,
+}
+
+impl ChangeLog {
+    pub(crate) fn new(id: VaultId) -> Self { Self { id, changes: vec![] } }
+
+    pub fn id(&self) -> VaultId { self.id }
+
+    pub(crate) fn add(&mut self, change: Change) {
+        self.changes.push(change);
+    }
+
+    pub fn store<S: VaultStorage>(&mut self, storage: S) -> Result<(), S::StoreError> {
+        let _ = storage.store_vault(&self)?;
+        self.changes = Vec::new();
+        Ok(())
+    }
+}
+
+pub trait VaultStorage {
+    type StoreError;
+    type LoadError;
+
+    fn create_vault(self, name: &str, parameters: VaultParameters) -> Result<(Vault, ChangeLog), Self::StoreError>;
+
+    fn load_vault(self, id: VaultId) -> Result<(Vault, ChangeLog), Self::LoadError>;
+
+    fn list_vaults(self) -> Result<Vec<(VaultId, String)>, Self::LoadError>;
+
+    // FIXME: Probably shouldn't be part of a public trait
+    fn store_vault(self, changes: &ChangeLog) -> Result<(), Self::StoreError>;
+}
+
+impl VaultStorage for &mut SqliteStorage {
+    type StoreError = StoreError;
+    type LoadError = LoadError;
+
+    fn create_vault(self, _name: &str, _parameters: VaultParameters) -> Result<(Vault, ChangeLog), Self::StoreError> {
+        todo!()
+    }
+
+    fn load_vault(self, _id: VaultId) -> Result<(Vault, ChangeLog), Self::LoadError> {
+        todo!()
+    }
+
+    fn store_vault(self, _changes: &ChangeLog) -> Result<(), Self::StoreError> {
+        todo!()
+    }
+
+    fn list_vaults(self) -> Result<Vec<(VaultId, String)>, Self::LoadError> {
+        todo!()
+    }
+}

--- a/src/transaction.rs
+++ b/src/transaction.rs
@@ -1,0 +1,1802 @@
+use bitcoin::{
+    Amount,
+    blockdata::locktime::relative,
+    blockdata::locktime::absolute,
+    FeeRate,
+    OutPoint,
+    psbt,
+    Sequence,
+    sighash,
+    script::Builder,
+    Script,
+    ScriptBuf,
+    Txid,
+    TxIn,
+    TxOut,
+    taproot,
+    transaction,
+    Transaction,
+    VarInt,
+    Weight,
+    Witness,
+};
+
+use bitcoin::bip32::{
+    Xpriv,
+    ChildNumber,
+};
+
+use bitcoin::hashes::{
+    Hash,
+    sha256,
+};
+
+use bitcoin::key::{
+    TapTweak,
+};
+
+use bitcoin::opcodes::all::{
+    OP_CSV,
+    OP_CHECKSIG,
+    OP_NOP4 as OP_CHECKTEMPLATEVERIFY,
+    OP_DROP,
+};
+
+use bitcoin::secp256k1::{
+    constants::SCHNORR_SIGNATURE_SIZE,
+    Keypair,
+    Message,
+    Secp256k1,
+    Signing,
+    Verification,
+    XOnlyPublicKey,
+};
+
+use bitcoin::taproot::{
+    ControlBlock,
+    LeafVersion,
+    TapLeafHash,
+    TapNodeHash,
+    TaprootBuilder,
+    TaprootMerkleBranch,
+    TaprootSpendInfo,
+};
+
+use std::borrow::Borrow;
+use std::collections::HashMap;
+use std::iter;
+
+use crate::bip119::get_default_template;
+
+use crate::vault::{
+    Depth,
+    massage_script_map,
+    OutputSpendingConditions,
+    spend_condition_lookup,
+    VaultAmount,
+    VaultParameters,
+    VaultScale,
+    VaultTransition,
+};
+
+use crate::wallet::{
+    SEGWIT_MARKER_WEIGHT,
+    UnderpayingParentTransaction,
+};
+
+pub fn builder_with_capacity(size: usize) -> Builder {
+    Builder::from(Vec::with_capacity(size))
+}
+
+pub fn dummy_input(lock_time: relative::LockTime) -> TxIn {
+    TxIn {
+        previous_output: OutPoint {
+            txid: Txid::from_byte_array([0u8; 32]),
+            vout: 0,
+        },
+        script_sig: ScriptBuf::new(),
+        sequence: lock_time.to_sequence(),
+        witness: Witness::new(),
+    }
+}
+
+#[derive(Copy, Clone, Debug)]
+pub struct TimelockedSpend {
+    timelock: relative::LockTime,
+    pubkey: XOnlyPublicKey,
+}
+
+impl TimelockedSpend {
+    pub fn to_scriptbuf(&self) -> ScriptBuf {
+        builder_with_capacity(5 + 1 + 33 + 1)
+            .push_int(self.timelock.to_consensus_u32() as i64)
+            .push_opcode(OP_CSV)
+            .push_opcode(OP_DROP)
+            .push_x_only_key(&self.pubkey)
+            .push_opcode(OP_CHECKSIG)
+            .into_script()
+    }
+}
+
+const PAY_TO_ANCHOR_SCRIPT_BYTES: &[u8] = &[0x51, 0x02, 0x4e, 0x73];
+
+pub fn ephemeral_anchor() -> TxOut {
+    let script_pubkey = ScriptBuf::from_bytes(PAY_TO_ANCHOR_SCRIPT_BYTES.to_vec());
+
+    TxOut {
+        value: Amount::from_sat(0),
+        script_pubkey,
+    }
+}
+
+pub fn is_ephemeral_anchor(txout: &TxOut) -> bool {
+    txout.value == Amount::ZERO
+        && txout.script_pubkey.as_script() == Script::from_bytes(PAY_TO_ANCHOR_SCRIPT_BYTES)
+}
+
+fn witness_item_weight(len: usize) -> Weight {
+    Weight::from_wu_usize(VarInt(len as u64).size() + len)
+}
+
+/// Calculate the serialized length of a single transaction input's witness
+fn witness_weight(merkle_branches: Option<(usize, usize)>, stack_item_sizes: &[u64]) -> Weight {
+    let extra_stack_item_sizes: &[Weight] = if let Some((script_len, merkle_branches)) = merkle_branches {
+        let cb_length = 33 + 32 * merkle_branches;
+
+        &[
+            witness_item_weight(script_len),
+            witness_item_weight(cb_length),
+        ]
+    } else {
+        &[]
+    };
+
+    let stack_item_count_len = VarInt(
+        stack_item_sizes.len() as u64 +
+        extra_stack_item_sizes.len() as u64
+    ).size();
+
+    stack_item_sizes.iter()
+        .map(|size| witness_item_weight(*size as usize))
+        .chain(extra_stack_item_sizes.into_iter().cloned())
+        .chain(Some(Weight::from_wu_usize(stack_item_count_len)))
+        .sum()
+}
+
+pub(crate) struct RecoveryTransactionTemplate {
+    recovery_key: XOnlyPublicKey,
+    vault_amount: VaultAmount,
+    withdrawal_amount: VaultAmount,
+    scale: VaultScale,
+}
+
+impl RecoveryTransactionTemplate {
+    pub fn to_transaction<C: Verification>(&self, secp: &Secp256k1<C>) -> Transaction {
+        let recovered_amount = self.vault_amount + self.withdrawal_amount;
+
+        assert!(recovered_amount > VaultAmount::ZERO);
+
+        let mut input: Vec<TxIn> = Vec::with_capacity(2);
+        if self.vault_amount > VaultAmount::ZERO {
+            input.push(dummy_input(relative::LockTime::ZERO));
+        }
+
+        if self.withdrawal_amount > VaultAmount::ZERO {
+            input.push(dummy_input(relative::LockTime::ZERO));
+        }
+
+        let recovery_output = TxOut {
+            value: self.scale.scale_amount(recovered_amount),
+            script_pubkey: ScriptBuf::new_p2tr(secp, self.recovery_key, None),
+        };
+
+        Transaction {
+            version: transaction::Version::non_standard(3),
+            lock_time: absolute::LockTime::ZERO,
+            input,
+            output: vec![recovery_output, ephemeral_anchor()],
+        }
+    }
+
+    pub fn get_default_template<C: Verification>(&self, secp: &Secp256k1<C>, input_index: u32) -> sha256::Hash {
+        // TODO: Do something less wasteful
+        let transaction = self.to_transaction(secp);
+
+        get_default_template(&transaction, input_index)
+    }
+}
+
+#[derive(Clone, Debug)]
+pub(crate) struct DepositTransactionTemplateCommon {
+    depth: Depth,
+    vault_scale: VaultScale,
+    pub vault_output: TxOut,
+    vault_deposit: VaultAmount,
+    vault_total: VaultAmount,
+}
+
+#[derive(Clone, Debug)]
+pub(crate) struct InitialDepositTransactionTemplate {
+    common: DepositTransactionTemplateCommon,
+}
+
+#[derive(Clone, Debug)]
+pub(crate) struct TailDepositTransactionTemplate {
+    common: DepositTransactionTemplateCommon,
+    vault_input_lock_time: relative::LockTime,
+}
+
+#[derive(Clone, Debug)]
+pub(crate) enum DepositTransactionTemplate {
+    InitialDeposit(InitialDepositTransactionTemplate),
+    Deposit(TailDepositTransactionTemplate),
+}
+
+impl DepositTransactionTemplate {
+    fn common(&self) -> &DepositTransactionTemplateCommon {
+        match self {
+            DepositTransactionTemplate::InitialDeposit(deposit) => &deposit.common,
+            DepositTransactionTemplate::Deposit(deposit) => &deposit.common,
+        }
+    }
+}
+
+impl DepositTransactionTemplateCommon {
+    // XXX: Should it return InitialDepositTransactionTemplate instead?
+    // I think this makes sense for now
+    pub fn into_initial_deposit_template(self) -> DepositTransactionTemplate {
+        DepositTransactionTemplate::InitialDeposit(
+            InitialDepositTransactionTemplate { common: self }
+        )
+    }
+
+    pub fn into_tail_deposit_template(self, vault_input_lock_time: relative::LockTime) -> DepositTransactionTemplate {
+        DepositTransactionTemplate::Deposit(
+            TailDepositTransactionTemplate { common: self, vault_input_lock_time }
+        )
+    }
+
+    fn to_transaction(self, vault_input: Option<TxIn>) -> Transaction {
+        let input = iter::empty()
+            .chain(Some(dummy_input(relative::LockTime::ZERO)))
+            .chain(vault_input)
+            .collect();
+
+        Transaction {
+            version: transaction::Version::non_standard(3),
+            lock_time: absolute::LockTime::ZERO,
+            input,
+            output: vec![self.vault_output],
+        }
+    }
+}
+
+impl InitialDepositTransactionTemplate {
+    pub fn instantiate(self, deposit_input_internal_key: XOnlyPublicKey) -> InitialDepositTransaction {
+        InitialDepositTransaction {
+            common: DepositTransactionCommon::from_template(self.common, deposit_input_internal_key)
+        }
+    }
+
+    pub fn vault_output(&self) -> &TxOut { &self.common.vault_output }
+}
+
+impl From<InitialDepositTransactionTemplate> for Transaction {
+    fn from(value: InitialDepositTransactionTemplate) -> Self {
+        value.common.to_transaction(None)
+    }
+}
+
+#[derive(Clone,Debug)]
+pub struct DepositTransactionCommon {
+    depth: Depth,
+    vault_scale: VaultScale,
+    vault_deposit: VaultAmount,
+    #[allow(dead_code)]
+    vault_total: VaultAmount,
+
+    deposit_input_internal_key: XOnlyPublicKey,
+    deposit_input: Option<(TxOut, TxIn)>,
+
+    vault_output: TxOut,
+}
+
+#[derive(Clone,Debug)]
+pub struct InitialDepositTransaction {
+    common: DepositTransactionCommon,
+}
+
+#[derive(Clone,Debug)]
+pub enum VaultTransactionBuildError {
+    // This will always be a deposit input, rename?
+    MissingInput,
+    NotSigned,
+}
+
+impl TryFrom<InitialDepositTransaction> for Transaction {
+    type Error = VaultTransactionBuildError;
+
+    fn try_from(value: InitialDepositTransaction) -> Result<Self, Self::Error> {
+        Ok(
+            Self {
+                version: transaction::Version::non_standard(3),
+                lock_time: absolute::LockTime::ZERO,
+                input: vec![
+                    value.common.deposit_input.map(|(_txout, txin)| txin).ok_or(VaultTransactionBuildError::MissingInput)?,
+                ],
+                output: vec![
+                    value.common.vault_output
+                ],
+            }
+        )
+    }
+}
+
+#[derive(Clone,Debug)]
+pub struct TailDepositTransaction {
+    common: DepositTransactionCommon,
+
+    vault_input: TxIn,
+    /// Information required to sign the vault output that this transaction spends
+    signing_info: VaultOutputSigningInfo,
+    signature: Option<taproot::Signature>,
+}
+
+#[derive(Clone,Debug)]
+pub enum DepositTransaction {
+    InitialDeposit(InitialDepositTransaction),
+    Deposit(TailDepositTransaction),
+}
+
+#[derive(Debug)]
+pub enum KeypairDerivationError {
+    WrongKey,
+    DerivationDepthExceeded,
+    NoSigningInfo,
+}
+
+
+#[derive(Clone, Debug)]
+pub enum DepositSignError {
+    NoSignatureNeeded,
+    SighashError(sighash::TaprootError),
+    NoShapeTransaction,
+}
+
+impl DepositTransaction {
+    const DEPOSIT_INPUT_INDEX_INITIAL: usize = 0;
+    const DEPOSIT_INPUT_INDEX_TAIL: usize = 1;
+
+    fn common(&self) -> &DepositTransactionCommon {
+        match self {
+            DepositTransaction::InitialDeposit(deposit) => &deposit.common,
+            DepositTransaction::Deposit(deposit) => &deposit.common,
+        }
+    }
+
+    fn deposit_witness<C: Verification>(&self, secp: &Secp256k1<C>) -> Witness {
+        let internal_key = self.common().deposit_input_internal_key;
+
+        let script_hash = TapNodeHash::from(self.deposit_script_hash());
+
+        let (_output_key, output_key_parity) = internal_key.tap_tweak(secp, Some(script_hash));
+
+        let mut witness = Witness::new();
+
+        let control_block = ControlBlock {
+            leaf_version: LeafVersion::TapScript,
+            output_key_parity,
+            internal_key,
+            merkle_branch: TaprootMerkleBranch::default(),
+        };
+
+        witness.push(self.deposit_script());
+        witness.push(control_block.serialize());
+
+        witness
+    }
+
+    fn vault_input(&self) -> Option<&TxIn> {
+        match self {
+            DepositTransaction::InitialDeposit(_deposit) => None,
+            DepositTransaction::Deposit(deposit) => Some(&deposit.vault_input),
+        }
+    }
+
+    /// Builds a [`bitcoin::Transaction`] from this [`Self`]
+    ///
+    /// Note that the result transaction may be partially or fully signed.
+    // XXX: Consider renaming to reduce (my own) confusion
+    fn to_unsigned_transaction(&self) -> Result<Transaction, VaultTransactionBuildError> {
+        match self {
+            DepositTransaction::InitialDeposit(deposit) => {
+                deposit.common.to_transaction(None)
+            }
+            DepositTransaction::Deposit(deposit) => {
+                deposit.common.to_transaction(Some(deposit.vault_input.clone()))
+            }
+        }
+    }
+
+    pub fn to_signed_transaction(&self) -> Result<Transaction, VaultTransactionBuildError> {
+        match self {
+            DepositTransaction::InitialDeposit(deposit) => {
+                deposit.common.to_transaction(None)
+            }
+            DepositTransaction::Deposit(deposit) => {
+                if let Some(signature) = deposit.signature {
+                    let mut vault_input = deposit.vault_input.clone();
+                    vault_input.witness = deposit.signing_info.build_witness(signature);
+
+                    deposit.common.to_transaction(Some(vault_input))
+                } else {
+                    Err(VaultTransactionBuildError::NotSigned)
+                }
+            }
+        }
+    }
+
+    // TODO: Estimate weight without constructing the whole transaction
+    pub fn weight<C: Verification>(&self, secp: &Secp256k1<C>) -> Weight {
+        let dummy_deposit = {
+            let mut dummy = dummy_input(relative::LockTime::ZERO);
+
+            dummy.witness = self.deposit_witness(secp);
+
+            dummy
+        };
+
+        let input = match self {
+            DepositTransaction::InitialDeposit(_deposit) => vec![dummy_deposit],
+            DepositTransaction::Deposit(deposit) => {
+                let mut vault_input = deposit.vault_input.clone();
+
+                let dummy_signature = taproot::Signature::from_slice(&[0u8; 64]).expect("valid dummy signature");
+                vault_input.witness = deposit.signing_info.build_witness(dummy_signature);
+
+                vec![vault_input, dummy_deposit]
+            }
+        };
+
+        let tx = Transaction {
+            version: transaction::Version::non_standard(3),
+            lock_time: absolute::LockTime::ZERO,
+            input,
+            output: vec![self.common().vault_output.clone()],
+        };
+
+        tx.weight()
+    }
+
+    /// Generates the template hash for the deposit (shape/prepare) transaction input
+    fn deposit_template_hash(&self) -> sha256::Hash {
+        let deposit_input_index = match self {
+            DepositTransaction::InitialDeposit(_) => Self::DEPOSIT_INPUT_INDEX_INITIAL,
+            DepositTransaction::Deposit(_) => Self::DEPOSIT_INPUT_INDEX_TAIL,
+        };
+
+        self.common().template_hash(
+            self.vault_input().cloned(),
+            deposit_input_index as u32,
+        )
+    }
+
+    fn deposit_script(&self) -> ScriptBuf {
+        let template_hash = self.deposit_template_hash();
+
+        builder_with_capacity(33 + 1 + 1 + 33 + 1)
+            .push_slice(template_hash.to_byte_array())
+            .push_opcode(OP_CHECKTEMPLATEVERIFY)
+            .into_script()
+    }
+
+    #[allow(dead_code)]
+    // This will be used directly once I defer generation of the deposit input witness
+    fn deposit_script_hash(&self) -> TapLeafHash {
+        let script = self.deposit_script();
+
+        TapLeafHash::from_script(
+            script.as_script(),
+            LeafVersion::TapScript,
+        )
+    }
+
+    // TODO: Devise a better API
+    pub fn hot_keypair<C: Signing>(&self, secp: &Secp256k1<C>, xpriv: &Xpriv) -> Result<Keypair, KeypairDerivationError> {
+        match self {
+            DepositTransaction::InitialDeposit(_) => Err(KeypairDerivationError::NoSigningInfo),
+            DepositTransaction::Deposit(deposit) => {
+                let parent_depth = deposit.common.depth - 1;
+                let keypair = xpriv.derive_priv(secp, &[
+                    ChildNumber::from_normal_idx(parent_depth as u32)
+                        .expect("assume sane child number")
+                ])
+                .map(|xpriv| xpriv.to_keypair(secp))
+                .map_err(|e| {
+                    match e {
+                        bitcoin::bip32::Error::MaximumDepthExceeded => KeypairDerivationError::DerivationDepthExceeded,
+                        _ => unreachable!("Xpriv derivation can only fail with maximum depth"),
+                    }
+                })?;
+
+                Ok(keypair)
+            }
+        }
+    }
+
+    // TODO: make it simple for the caller to lookup the correct keys
+    pub fn sign_vault_input<C: Signing>(&mut self, secp: &Secp256k1<C>, keys: &Keypair) -> Result<(), DepositSignError> {
+        // Had to hoist the into_unsigned_transaction() here because 'self' is already mutably
+        // borrowed in the match. Annoying, clean this up later.
+        let transaction = self.to_unsigned_transaction()
+            .map_err(|e| {
+                match e {
+                    VaultTransactionBuildError::MissingInput => DepositSignError::NoShapeTransaction,
+                    // FIXME: not in love with having yet another panic location
+                    VaultTransactionBuildError::NotSigned => unreachable!("to_unsigned_transaction() won't produce this error"),
+                }
+            })?;
+
+        match self {
+            DepositTransaction::InitialDeposit(_) => Ok(()),
+            // Previous version returned Err(DepositSignError::NoSignatureNeeded)
+            // do we care? should we care? I'm inclined to let it go silently...
+            DepositTransaction::Deposit(ref mut deposit) => {
+                let prevout_txouts = vec![
+                    &deposit.signing_info.vault_prevout,
+                    deposit.common.deposit_input
+                        .as_ref()
+                        .map(|(txout, _txin)| txout)
+                        .ok_or(DepositSignError::NoShapeTransaction)?
+                ];
+
+                let prevouts = sighash::Prevouts::All(&prevout_txouts);
+
+                deposit.signature = Some(deposit.signing_info.sign(secp, keys, &transaction, 0, &prevouts)
+                    .map_err(|e| DepositSignError::SighashError(e))?
+                );
+
+                Ok(())
+            }
+        }
+    }
+
+    pub fn payment_info<C: Verification>(&self, secp: &Secp256k1<C>) -> (ScriptBuf, Amount) {
+        let pubkey = self.common().deposit_input_internal_key;
+        let scale = self.common().vault_scale;
+        let amount = scale.scale_amount(self.common().vault_deposit);
+        let script_hash = TapNodeHash::from(self.deposit_script_hash());
+        let script_pubkey = ScriptBuf::new_p2tr(secp, pubkey, Some(script_hash));
+
+        (script_pubkey, amount)
+    }
+
+    pub fn connect_input<C: Verification>(&mut self, secp: &Secp256k1<C>, previous_output: OutPoint, txout: TxOut) {
+        let deposit_input = TxIn {
+            previous_output,
+            script_sig: ScriptBuf::new(),
+            sequence: Sequence::ZERO,
+            witness: self.deposit_witness(secp),
+        };
+
+        match self {
+            DepositTransaction::InitialDeposit(ref mut deposit) => {
+                deposit.common.deposit_input = Some((txout, deposit_input));
+            }
+            DepositTransaction::Deposit(ref mut deposit) => {
+                deposit.common.deposit_input = Some((txout, deposit_input));
+            }
+        }
+    }
+}
+
+impl DepositTransactionCommon {
+    pub fn from_template(common: DepositTransactionTemplateCommon, deposit_input_internal_key: XOnlyPublicKey) -> Self {
+        Self {
+            depth: common.depth,
+            deposit_input: None,
+            deposit_input_internal_key,
+            vault_scale: common.vault_scale,
+            vault_output: common.vault_output,
+            vault_deposit: common.vault_deposit,
+            vault_total: common.vault_total,
+        }
+    }
+
+    /// Build a deposit transaction from common elements and an optional vault input
+    ///
+    /// Whether or not the result is signed depends on the state of the deposit input and the
+    /// provided vault_input.
+    fn to_transaction(&self, vault_input: Option<TxIn>) -> Result<Transaction, VaultTransactionBuildError> {
+        let input = iter::empty()
+            .chain(vault_input)
+            .chain(
+                Some(
+                    self.deposit_input.as_ref().map(|(_txout, txin)| txin.clone()).ok_or(VaultTransactionBuildError::MissingInput)?
+                )
+            )
+            .collect();
+
+        Ok(
+            Transaction {
+                version: transaction::Version::non_standard(3),
+                lock_time: absolute::LockTime::ZERO,
+                input,
+                output: vec![self.vault_output.clone()],
+            }
+        )
+    }
+
+    fn template_hash(&self, vault_input: Option<TxIn>, input_index: u32) -> sha256::Hash {
+        let input = iter::empty()
+            .chain(vault_input)
+            .chain(Some(dummy_input(relative::LockTime::ZERO)))
+            .collect();
+
+        get_default_template(
+            &Transaction {
+                version: transaction::Version::non_standard(3),
+                lock_time: absolute::LockTime::ZERO,
+                input,
+                output: vec![self.vault_output.clone()],
+            },
+            input_index
+        )
+    }
+}
+
+impl TailDepositTransaction {
+    #[allow(dead_code)]
+    fn vault_template_hash(&self) -> sha256::Hash {
+        get_default_template(
+            &Transaction {
+                version: transaction::Version::non_standard(3),
+                lock_time: absolute::LockTime::ZERO,
+                input: vec![
+                    self.vault_input.clone(),
+                    dummy_input(relative::LockTime::ZERO),
+                ],
+                output: vec![self.common.vault_output.clone()],
+            },
+            0,
+        )
+    }
+}
+
+#[derive(Clone,Debug)]
+pub(crate) enum VaultTransactionTemplate {
+    Deposit(DepositTransactionTemplate),
+    Withdrawal(WithdrawalTransactionTemplate),
+}
+
+impl VaultTransactionTemplate {
+    pub fn vault_template_hash(&self) -> sha256::Hash {
+        match self {
+            VaultTransactionTemplate::Deposit(DepositTransactionTemplate::InitialDeposit(_deposit)) => unreachable!("initial deposit can't be the destination of a vault output"),
+            VaultTransactionTemplate::Deposit(DepositTransactionTemplate::Deposit(deposit)) => deposit.vault_template_hash(),
+            VaultTransactionTemplate::Withdrawal(withdrawal) => withdrawal.vault_template_hash(),
+        }
+    }
+
+    #[allow(dead_code)]
+    fn into_transition(&self) -> VaultTransition {
+        match self {
+            VaultTransactionTemplate::Deposit(DepositTransactionTemplate::InitialDeposit(deposit)) =>
+                VaultTransition::Deposit(deposit.common.vault_deposit),
+            VaultTransactionTemplate::Deposit(DepositTransactionTemplate::Deposit(deposit)) =>
+                VaultTransition::Deposit(deposit.common.vault_deposit),
+            VaultTransactionTemplate::Withdrawal(withdrawal) => VaultTransition::Withdrawal(withdrawal.vault_withdrawal),
+        }
+    }
+
+    #[allow(dead_code)]
+    fn vault_total(&self) -> VaultAmount {
+        match self {
+            VaultTransactionTemplate::Deposit(deposit) => deposit.common().vault_total,
+            VaultTransactionTemplate::Withdrawal(withdrawal) => withdrawal.vault_total,
+        }
+    }
+}
+
+#[derive(Clone,Debug)]
+pub(crate) struct WithdrawalTransactionTemplate {
+    depth: Depth,
+    vault_input_lock_time: relative::LockTime,
+    vault_output: Option<TxOut>,
+    pub withdrawal_output: TxOut,
+
+    vault_total: VaultAmount,
+    vault_withdrawal: VaultAmount,
+}
+
+impl WithdrawalTransactionTemplate {
+    pub fn instantiate(&self, vault_prevout: OutPoint, signing_info: VaultOutputSigningInfo, withdrawal_output_info: WithdrawalOutputSpendInfo) -> WithdrawalTransaction {
+        let vault_input = TxIn {
+            previous_output: vault_prevout,
+            script_sig: ScriptBuf::new(),
+            sequence: self.vault_input_lock_time.into(),
+            witness: Witness::new(),
+        };
+
+        WithdrawalTransaction {
+            depth: self.depth,
+            vault_total: self.vault_total,
+            vault_withdrawal: self.vault_withdrawal,
+            signing_info,
+            vault_input,
+            vault_signature: None,
+            vault_output: self.vault_output.clone(),
+            withdrawal_output: self.withdrawal_output.clone(),
+            withdrawal_output_info,
+        }
+    }
+
+    // TODO: implement optimized version without constructing the Transaction
+    fn vault_template_hash(&self) -> sha256::Hash {
+        let output = iter::empty()
+            // Vault output
+            .chain(self.vault_output.clone())
+            .chain(Some(self.withdrawal_output.clone()))
+            .chain(Some(ephemeral_anchor()))
+            .collect();
+
+        let tx = Transaction {
+            version: transaction::Version::non_standard(3),
+            lock_time: absolute::LockTime::ZERO,
+            input: vec![dummy_input(self.vault_input_lock_time)],
+            output,
+        };
+
+        get_default_template(&tx, 0)
+    }
+}
+
+// TODO: consider implementing [`OutputSpendingConditions`] so we can consolidate some things
+#[derive(Clone,Debug)]
+pub struct WithdrawalOutputSpendInfo {
+    timelock: relative::LockTime,
+    txout: TxOut,
+    single_recovery_script: ScriptBuf,
+    double_recovery_script: Option<ScriptBuf>,
+    timelocked_withdrawal_script: ScriptBuf,
+    hot_pubkey: XOnlyPublicKey,
+    master_pubkey: XOnlyPublicKey,
+    taproot_info: TaprootSpendInfo,
+}
+
+impl WithdrawalOutputSpendInfo {
+    pub fn from_parameters<C: Verification>(secp: &Secp256k1<C>, parameters: &VaultParameters, depth: Depth, timelock: relative::LockTime, vault_amount: VaultAmount, withdrawal_amount: VaultAmount) -> Self {
+        let master_pubkey = parameters.master_key(secp, depth);
+        let hot_pubkey = parameters.hot_key(secp, depth);
+        let recovery_key = parameters.hot_key(secp, depth + 1);
+
+        let timelocked_withdrawal_script = TimelockedSpend { pubkey: hot_pubkey, timelock };
+        let timelocked_withdrawal_script = timelocked_withdrawal_script.to_scriptbuf();
+
+        // NOTE: The templates are at `depth + 1`, but the scripts are at `depth`
+        // FIXME:this could all be pretty lazily created imho, but let's not create more work for
+        // ourselves right now
+        let single_recovery_template = RecoveryTransactionTemplate { recovery_key, vault_amount: VaultAmount::ZERO, withdrawal_amount, scale: parameters.scale };
+        let single_recovery_script = SignedNextStateTemplate {
+            pubkey: hot_pubkey,
+            next_state_template_hash: single_recovery_template.get_default_template(secp, 0),
+        };
+        let single_recovery_script = single_recovery_script.to_scriptbuf();
+
+        let double_recovery_script = if vault_amount > VaultAmount::ZERO {
+            let double_recovery_template = RecoveryTransactionTemplate { recovery_key, vault_amount, withdrawal_amount, scale: parameters.scale };
+
+            Some(
+                SignedNextStateTemplate {
+                    pubkey: hot_pubkey,
+                    next_state_template_hash: double_recovery_template.get_default_template(secp, 1),
+                }
+                .to_scriptbuf()
+            )
+        } else {
+            None
+        };
+
+        const SCRIPT_EXPECT_MSG: &str = "hard coded script construction succeeds";
+
+        let taproot_builder = if let Some(ref double_recovery) = double_recovery_script {
+            TaprootBuilder::new()
+                .add_leaf(2, single_recovery_script.clone())
+                    .expect(SCRIPT_EXPECT_MSG)
+                .add_leaf(2, double_recovery.clone())
+                    .expect(SCRIPT_EXPECT_MSG)
+                .add_leaf(1, timelocked_withdrawal_script.clone())
+                    .expect(SCRIPT_EXPECT_MSG)
+        } else {
+            TaprootBuilder::new()
+                .add_leaf(1, single_recovery_script.clone())
+                    .expect(SCRIPT_EXPECT_MSG)
+                .add_leaf(1, timelocked_withdrawal_script.clone())
+                    .expect(SCRIPT_EXPECT_MSG)
+        };
+
+        let taproot_info = taproot_builder
+            .finalize(secp, master_pubkey)
+                .expect("finalize"); // FIXME: 80% sure this can only fail if our script construction is wrong
+
+        let txout = TxOut {
+            value: parameters.scale.scale_amount(withdrawal_amount),
+            script_pubkey: ScriptBuf::new_p2tr_tweaked(
+                taproot_info.output_key(),
+            ),
+        };
+
+        WithdrawalOutputSpendInfo {
+            timelock,
+            txout,
+            single_recovery_script,
+            double_recovery_script,
+            timelocked_withdrawal_script,
+            hot_pubkey,
+            master_pubkey,
+            taproot_info,
+        }
+    }
+
+    pub fn master_pubkey(&self) -> XOnlyPublicKey { self.master_pubkey }
+
+    pub fn spend_condition_lookup(&self) -> HashMap<TaprootMerkleBranch, (WithdrawalSpendingCondition, &Script)> {
+        let conditions = |s: &Script| {
+            if s == self.timelocked_withdrawal_script.as_script() {
+                Some(
+                    (
+                        WithdrawalSpendingCondition::TimelockedSpend,
+                        self.timelocked_withdrawal_script.as_script(),
+                    )
+                )
+            } else if s == self.single_recovery_script.as_script() {
+                Some(
+                    (
+                        WithdrawalSpendingCondition::RecoveryWithdrawalOnly,
+                        self.single_recovery_script.as_script(),
+                    )
+                )
+            } else if let Some(ref double_recovery_script) = self.double_recovery_script {
+                if s == double_recovery_script.as_script() {
+                    Some(
+                        (
+                            WithdrawalSpendingCondition::Recovery,
+                            double_recovery_script.as_script()
+                        )
+                    )
+                } else {
+                    None
+                }
+            } else {
+                None
+            }
+        };
+
+        spend_condition_lookup(
+            self.taproot_info.script_map()
+                .iter()
+                .map(massage_script_map),
+                conditions,
+        )
+    }
+
+    pub fn into_withdrawal_template(&self, depth: Depth, vault_output_spend_info: Option<VaultOutputSpendInfo>, vault_input_lock_time: relative::LockTime, vault_total: VaultAmount, withdrawal_amount: VaultAmount, scale: VaultScale) -> WithdrawalTransactionTemplate {
+        let withdrawal_output = TxOut {
+            value: scale.scale_amount(withdrawal_amount),
+            script_pubkey: self.script_pubkey(),
+        };
+
+        WithdrawalTransactionTemplate {
+            depth,
+            vault_output: vault_output_spend_info.map(|info| info.output),
+            withdrawal_output,
+            vault_total,
+            vault_withdrawal: withdrawal_amount,
+            vault_input_lock_time,
+        }
+    }
+
+    pub fn to_signing_info<C: Verification>(&self, secp: &Secp256k1<C>, prevout: TxOut, condition: WithdrawalSpendingCondition) -> Option<WithdrawalOutputSigningInfo> {
+        let (_output_key, output_key_parity) =
+            self.master_pubkey
+            .tap_tweak(
+                secp,
+                Some(self.root_node_hash())
+            );
+
+        let script = self.script(condition)?;
+
+        let control_block = ControlBlock {
+            leaf_version: LeafVersion::TapScript,
+            output_key_parity,
+            internal_key: self.master_pubkey,
+            merkle_branch: self.merkle_branch(script.to_owned())?,
+        };
+
+        Some(
+            WithdrawalOutputSigningInfo {
+                pubkey: self.hot_pubkey,
+                control_block: control_block,
+                // XXX: note this name is misleading, since we typedef'd VaultOutputSigningInfo to
+                // WithdrawalOutputSigningInfo
+                vault_prevout: prevout,
+                script: script.to_owned(),
+            }
+        )
+    }
+
+    fn script(&self, condition: WithdrawalSpendingCondition) -> Option<&Script> {
+        match condition {
+            WithdrawalSpendingCondition::Recovery => self.double_recovery_script.as_ref().map(|script| script.as_script()),
+            WithdrawalSpendingCondition::RecoveryWithdrawalOnly => Some(&self.single_recovery_script),
+            WithdrawalSpendingCondition::TimelockedSpend => Some(&self.timelocked_withdrawal_script),
+        }
+    }
+
+    pub fn root_node_hash(&self) -> TapNodeHash {
+        self.taproot_info.merkle_root()
+            .expect("must have merkle root")
+    }
+
+    pub fn script_pubkey(&self) -> ScriptBuf {
+        ScriptBuf::new_p2tr_tweaked(self.taproot_info.output_key())
+    }
+
+    fn merkle_branch(&self, script: ScriptBuf) -> Option<TaprootMerkleBranch> {
+        self.taproot_info
+            .script_map()
+            .get(
+                &(
+                    script,
+                    LeafVersion::TapScript,
+                )
+            )?
+            .iter()
+            .next()
+            .cloned()
+    }
+
+    fn timelocked_withdrawal_merkle_branch(&self) -> TaprootMerkleBranch {
+        self.merkle_branch(self.timelocked_withdrawal_script.clone())
+            .expect("withdrawal condition always exists")
+    }
+}
+
+#[derive(Clone)]
+pub enum WithdrawalSpendingCondition {
+    /// Recovery transaction spending the withdrawal output with the vault output
+    Recovery,
+    // FIXME: Do we need to care if the vault output is present? Too tired to figure it out right
+    // now...
+    /// Recovery transaction only spending the withdrawal output, regardless of if the vault output
+    /// is present
+    RecoveryWithdrawalOnly,
+    /// Spends the withdrawal output using the hot key to any transaction after a timelock  
+    TimelockedSpend,
+}
+
+impl OutputSpendingConditions<WithdrawalSpendingCondition> for WithdrawalOutputSpendInfo {
+    type SpendingCondition = WithdrawalOutputSigningInfo;
+
+	fn get_spending_condition(&self, selector: WithdrawalSpendingCondition) -> Option<Self::SpendingCondition> {
+        let script = (
+            self.script(selector)?.to_owned(),
+            LeafVersion::TapScript,
+        );
+
+        let control_block = self.taproot_info.control_block(&script)?;
+
+        Some(
+            WithdrawalOutputSigningInfo {
+                // FIXME: pubkey, is that right?
+                pubkey: self.hot_pubkey,
+                control_block,
+                vault_prevout: self.txout.clone(),
+                script: script.0,
+            }
+        )
+    }
+}
+
+#[allow(dead_code)]
+#[derive(Clone,Debug)]
+pub struct WithdrawalTransaction {
+    depth: Depth,
+    vault_input: TxIn,
+    vault_signature: Option<taproot::Signature>,
+    vault_output: Option<TxOut>,
+    withdrawal_output: TxOut,
+
+    vault_total: VaultAmount,
+    vault_withdrawal: VaultAmount,
+
+    withdrawal_output_info: WithdrawalOutputSpendInfo,
+
+    /// Information required to sign the vault output that this transaction spends
+    signing_info: VaultOutputSigningInfo,
+}
+
+#[derive(Clone, Debug)]
+pub enum WithdrawalSignError {
+    SighashError(sighash::TaprootError),
+}
+
+impl WithdrawalTransaction {
+    fn into_transaction(self) -> Transaction {
+        let output = iter::empty()
+            .chain(self.vault_output)
+            .chain(Some(self.withdrawal_output))
+            .chain(Some(ephemeral_anchor()))
+            .collect();
+
+        Transaction {
+            version: transaction::Version::non_standard(3),
+            lock_time: absolute::LockTime::ZERO,
+            input: vec![self.vault_input],
+            output,
+        }
+    }
+
+    // TODO: eliminate need to construct transaction
+    fn compute_txid(&self) -> Txid {
+        let tx: Transaction = self.clone().into_transaction();
+
+        tx.compute_txid()
+    }
+
+    pub fn anchor_outpoint(&self) -> OutPoint {
+        OutPoint {
+            txid: self.compute_txid(),
+            vout: if self.vault_output.is_some() {
+                2
+            } else {
+                1
+            },
+        }
+    }
+
+    pub fn anchor_output_psbt_input(&self) -> psbt::Input {
+        psbt::Input {
+            witness_utxo: Some(ephemeral_anchor()),
+            non_witness_utxo: Some(self.clone().into_transaction()),
+            final_script_witness: Some(Witness::new()),
+            ..Default::default()
+        }
+    }
+
+    pub fn hot_keypair<C: Signing>(&self, secp: &Secp256k1<C>, xpriv: &Xpriv) -> Result<Keypair, KeypairDerivationError> {
+        let parent_depth = self.depth - 1;
+        let keypair = xpriv.derive_priv(secp, &[
+            ChildNumber::from_normal_idx(parent_depth as u32)
+                .expect("sane child number")
+        ])
+        .map(|xpriv| xpriv.to_keypair(secp))
+        .map_err(|e| {
+            match e {
+                bitcoin::bip32::Error::MaximumDepthExceeded => KeypairDerivationError::DerivationDepthExceeded,
+                _ => unreachable!("Xpriv derivation can only fail with maximum depth"),
+            }
+        })?;
+
+        Ok(keypair)
+    }
+
+    // FIXME: Result instead of Option?
+    pub fn to_signed_transaction(&self) -> Option<Transaction> {
+        let mut vault_input = self.vault_input.clone();
+        vault_input.witness = self.signing_info.build_witness(self.vault_signature?);
+
+        let output = iter::empty()
+            .chain(self.vault_output.clone())
+            .chain(Some(self.withdrawal_output.clone()))
+            .chain(Some(ephemeral_anchor()))
+            .collect();
+
+        Some(
+            Transaction {
+                version: transaction::Version::non_standard(3),
+                lock_time: absolute::LockTime::ZERO,
+                input: vec![vault_input],
+                output,
+            }
+        )
+    }
+
+    pub fn spend_withdrawal(self) -> WithdrawalSpendTransaction {
+        WithdrawalSpendTransaction {
+            depth: self.depth,
+            prevout: OutPoint {
+                txid: self.compute_txid(),
+                vout: if self.vault_output.is_some() {
+                    1
+                } else {
+                    0
+                },
+            },
+            withdrawal_output: self.withdrawal_output,
+            withdrawal_output_info: self.withdrawal_output_info,
+        }
+    }
+
+    pub fn weight(&self) -> Weight {
+        let serialized_schnorr_sig_len = VarInt(SCHNORR_SIGNATURE_SIZE as u64).size() as u64 + SCHNORR_SIGNATURE_SIZE as u64;
+        let script_len = self.signing_info.script.len() as u64;
+        let serialized_script_len = VarInt(script_len).size() as u64 + script_len;
+        let control_block_len = self.signing_info.control_block.size() as u64;
+        let serialized_control_block_len = VarInt(control_block_len).size() as u64 + control_block_len;
+
+        self.clone().into_transaction().weight() +
+            if self.vault_signature.is_some() {
+                // We've already been signed, rust-bitcoin will
+                // calculate the correct weight
+                Weight::ZERO
+            } else {
+                Weight::from_wu(
+                    2 + 1 + // Segwit marker + witness item count
+                    serialized_schnorr_sig_len +
+                    serialized_script_len +
+                    serialized_control_block_len
+                )
+            }
+    }
+
+    pub fn sign_vault_input<C: Signing>(&mut self, secp: &Secp256k1<C>, keypair: &Keypair) -> Result<(), WithdrawalSignError> {
+        let prevout_txouts = vec![
+            &self.signing_info.vault_prevout,
+        ];
+
+        // TODO: also check that we actually satisfy the script, probably facilitated by hanging
+        // onto the script template instead of the serialized ScriptBuf
+        let prevouts = sighash::Prevouts::All(&prevout_txouts);
+
+        let transaction = self.clone().into_transaction();
+
+        let signature = self.signing_info.sign(secp, keypair, &transaction, 0, &prevouts)
+            .map_err(|e| WithdrawalSignError::SighashError(e))?;
+
+        self.vault_signature = Some(signature);
+
+        Ok(())
+    }
+}
+
+#[derive(Clone,Debug)]
+pub enum WithdrawalSpendError {
+    FeeTooLarge,
+    SighashError(sighash::TaprootError),
+    FeeOverflow,
+}
+
+#[derive(Clone,Debug)]
+pub struct WithdrawalSpendTransaction {
+    depth: Depth,
+    prevout: OutPoint,
+    withdrawal_output: TxOut,
+    withdrawal_output_info: WithdrawalOutputSpendInfo,
+}
+
+impl WithdrawalSpendTransaction {
+    pub fn timelock(&self) -> relative::LockTime {
+        self.withdrawal_output_info.timelock
+    }
+
+    pub fn hot_keypair<C: Signing>(&self, secp: &Secp256k1<C>, xpriv: &Xpriv) -> Result<Keypair, KeypairDerivationError> {
+        let keypair = xpriv.derive_priv(secp, &[
+            ChildNumber::from_normal_idx(self.depth as u32)
+                .expect("sane child number")
+        ])
+        .map(|xpriv| xpriv.to_keypair(secp))
+        .map_err(|e| {
+            match e {
+                bitcoin::bip32::Error::MaximumDepthExceeded => KeypairDerivationError::DerivationDepthExceeded,
+                _ => unreachable!("Xpriv derivation can only fail with maximum depth"),
+            }
+        })?;
+
+        if self.withdrawal_output_info.hot_pubkey != keypair.x_only_public_key().0 {
+            Err(KeypairDerivationError::WrongKey)
+        } else {
+            Ok(keypair)
+        }
+    }
+
+    pub fn spend<C: Signing + Verification>(&self, secp: &Secp256k1<C>, keypair: &Keypair, script_pubkey: ScriptBuf, min_fee: Amount, min_fee_rate: FeeRate) -> Result<Transaction, WithdrawalSpendError> {
+        let mut transaction = Transaction {
+            version: transaction::Version::TWO,
+            lock_time: absolute::LockTime::ZERO,
+            input: vec![
+                TxIn {
+                    previous_output: self.prevout,
+                    script_sig: ScriptBuf::new(),
+                    sequence: self.withdrawal_output_info.timelock.into(),
+                    witness: Witness::new(),
+                },
+            ],
+            output: vec![
+                TxOut {
+                    value: self.withdrawal_output.value - min_fee,
+                    script_pubkey,
+                }
+            ],
+        };
+
+        if min_fee > self.withdrawal_output.value {
+            return Err(WithdrawalSpendError::FeeTooLarge);
+        }
+
+        let tap_leaf_hash = TapLeafHash::from_script(
+            self
+                .withdrawal_output_info
+                .timelocked_withdrawal_script
+                .as_script(),
+            LeafVersion::TapScript,
+        );
+
+        assert_eq!(
+            self.withdrawal_output_info.script_pubkey(),
+            self.withdrawal_output.script_pubkey,
+        );
+
+        let tap_node_hash = self.withdrawal_output_info.root_node_hash();
+
+        let (_output_key, output_key_parity) = self.withdrawal_output_info.master_pubkey.tap_tweak(secp, Some(tap_node_hash));
+
+        let control_block = ControlBlock {
+            leaf_version: LeafVersion::TapScript,
+            output_key_parity,
+            internal_key: self.withdrawal_output_info.master_pubkey,
+            merkle_branch: self.withdrawal_output_info.timelocked_withdrawal_merkle_branch(),
+        };
+
+        let script_len = self.withdrawal_output_info.timelocked_withdrawal_script.len();
+        let control_block_len = control_block.size();
+
+        let weight = transaction.weight()
+            + SEGWIT_MARKER_WEIGHT
+            + Weight::from_wu(VarInt(3).size() as u64) // 3 witness items
+            + Weight::from_wu(VarInt(SCHNORR_SIGNATURE_SIZE as u64).size() as u64)
+            + Weight::from_wu(SCHNORR_SIGNATURE_SIZE as u64)
+            + Weight::from_wu(VarInt(script_len as u64).size() as u64)
+            + Weight::from_wu(script_len as u64)
+            + Weight::from_wu(VarInt(control_block_len as u64).size() as u64)
+            + Weight::from_wu(control_block_len as u64);
+
+        let fee = min_fee_rate.checked_mul_by_weight(weight)
+            .ok_or(WithdrawalSpendError::FeeOverflow)?;
+
+        let fee = std::cmp::max(min_fee, fee);
+
+        transaction.output[0].value = self.withdrawal_output.value - fee;
+
+        let prevout_txouts = vec![
+            &self.withdrawal_output,
+        ];
+
+        let prevouts = sighash::Prevouts::All(&prevout_txouts);
+
+        let sighash = sighash::SighashCache::new(&transaction)
+            .taproot_signature_hash(0, &prevouts, None, Some((tap_leaf_hash, 0xFFFFFFFF)), sighash::TapSighashType::Default)
+            .map_err(|e| WithdrawalSpendError::SighashError(e))?;
+
+        // FIXME: seems like there should be shortcuts for a couple of these things?
+        let message: Message = sighash.into();
+        let signature = secp.sign_schnorr(&message, keypair);
+
+        let signature = taproot::Signature {
+            signature,
+            sighash_type: sighash::TapSighashType::Default,
+        };
+
+        transaction.input[0].witness.push(signature.serialize());
+        transaction.input[0].witness.push(
+            self
+                .withdrawal_output_info
+                .timelocked_withdrawal_script
+                .as_bytes()
+        );
+        transaction.input[0].witness.push(control_block.serialize());
+
+        Ok(transaction)
+    }
+}
+
+#[derive(Clone,Debug)]
+pub enum RecoveryTransactionInput {
+    /// Deposit or Withdrawal vault output without withdrawal output
+    /// u32 is the vault output
+    VaultOnly(VaultOutputSigningInfo, u32),
+    // u32 is the vout, it can vary depending on whether the withdrawal
+    // had a vault output or not.
+    WithdrawalOnly(WithdrawalOutputSigningInfo, u32),
+    Withdrawal {
+        vault: VaultOutputSigningInfo,
+        vault_vout: u32,
+        withdrawal: WithdrawalOutputSigningInfo,
+        withdrawal_vout: u32,
+    },
+}
+
+// FIXME: Refine this a little bit
+#[derive(Clone, Debug)]
+pub struct RecoveryTransaction {
+    depth: Depth,
+
+    prevout_txid: Txid,
+    input: RecoveryTransactionInput,
+
+    // TODO: Evaluate constructing this on demand instead
+    output: TxOut,
+
+    // FIXME: pretty goofy, should probably use an enum parallel to RecoveryTransactionSigningInfo
+    vault_signature: Option<taproot::Signature>,
+    withdrawal_signature: Option<taproot::Signature>,
+}
+
+impl RecoveryTransaction {
+    pub fn new<C: Verification>(secp: &Secp256k1<C>, depth: Depth, prevout_txid: Txid, recovery_key: XOnlyPublicKey, input: RecoveryTransactionInput, recovered_value: VaultAmount, scale: VaultScale) -> Self {
+        let script_pubkey = ScriptBuf::new_p2tr(secp, recovery_key, None);
+
+        let recovery_output = TxOut {
+            value: scale.scale_amount(recovered_value),
+            script_pubkey,
+        };
+
+        Self {
+            depth,
+            prevout_txid,
+            input,
+            output: recovery_output,
+            vault_signature: None,
+            withdrawal_signature: None,
+        }
+    }
+
+    pub(crate) fn to_unsigned_transaction(&self) -> Transaction {
+        let mk_input = |txid, vout| TxIn {
+            previous_output: OutPoint { txid, vout },
+            script_sig: ScriptBuf::new(),
+            sequence: Sequence::ZERO,
+            witness: Witness::new(),
+        };
+
+        let input = match &self.input {
+            RecoveryTransactionInput::VaultOnly(_vault, vault_vout) => vec![
+                mk_input(self.prevout_txid, *vault_vout),
+            ],
+            RecoveryTransactionInput::WithdrawalOnly(_withdrawal, vout) => vec![
+                mk_input(self.prevout_txid, *vout),
+            ],
+            RecoveryTransactionInput::Withdrawal { vault_vout, withdrawal_vout, .. } => vec![
+                mk_input(self.prevout_txid, *vault_vout),
+                mk_input(self.prevout_txid, *withdrawal_vout),
+            ],
+        };
+
+        Transaction {
+            version: transaction::Version::non_standard(3),
+            lock_time: absolute::LockTime::ZERO,
+            input,
+            output: vec![
+                self.output.clone(),
+                ephemeral_anchor(),
+            ],
+        }
+    }
+
+    // TODO: Devise a better API
+    pub fn hot_keypair<C: Signing>(&self, secp: &Secp256k1<C>, xpriv: &Xpriv) -> Result<Keypair, KeypairDerivationError> {
+        let parent_depth = self.depth - 1;
+
+        let keypair = xpriv.derive_priv(secp, &[
+            ChildNumber::from_normal_idx(parent_depth as u32)
+                .expect("assume sane child number")
+        ])
+        .map(|xpriv| xpriv.to_keypair(secp))
+        .map_err(|e| {
+            match e {
+                bitcoin::bip32::Error::MaximumDepthExceeded => KeypairDerivationError::DerivationDepthExceeded,
+                _ => unreachable!("Xpriv derivation can only fail with maximum depth"),
+            }
+        })?;
+
+        // TODO: Validate derived key's pubkey
+        Ok(keypair)
+    }
+
+    pub fn sign<C: Signing>(&mut self, secp: &Secp256k1<C>, keypair: &Keypair) -> Result<(), SignRecoveryError> {
+        let inputs = match &self.input {
+            RecoveryTransactionInput::VaultOnly(vault, _vout) =>
+                vec![&vault.vault_prevout],
+            RecoveryTransactionInput::WithdrawalOnly(withdrawal, _vout) =>
+                vec![&withdrawal.vault_prevout],
+            RecoveryTransactionInput::Withdrawal { vault, withdrawal, .. } =>
+                vec![
+                    &vault.vault_prevout,
+                    // FIXME: Slightly poorly named here, this is the withdrawal prevout...
+                    // Maybe VaultOutputSigningInfo should be renamed...
+                    // The key in this case is that it has the signing info we need
+                    &withdrawal.vault_prevout,
+                ],
+        };
+
+        let prevouts = sighash::Prevouts::All(&inputs);
+
+        let transaction = self.to_unsigned_transaction();
+
+        (self.vault_signature, self.withdrawal_signature) = match &self.input {
+            RecoveryTransactionInput::VaultOnly(vault, _vout) => {
+                (
+                    Some(vault.sign(secp, keypair, &transaction, 0, &prevouts).map_err(SignRecoveryError::SignError)?),
+                    None,
+                )
+            }
+            RecoveryTransactionInput::WithdrawalOnly(withdrawal, _vout) => {
+                (
+                    None,
+                    Some(withdrawal.sign(secp, keypair, &transaction, 1, &prevouts).map_err(SignRecoveryError::SignError)?),
+                )
+            }
+            RecoveryTransactionInput::Withdrawal { vault, withdrawal, .. } => {
+                // TODO: remove hard coded vault input indices, not a huge deal but I would like to
+                // centralize them more
+                (
+                    Some(vault.sign(secp, keypair, &transaction, 0, &prevouts).map_err(SignRecoveryError::SignError)?),
+                    Some(withdrawal.sign(secp, keypair, &transaction, 1, &prevouts).map_err(SignRecoveryError::SignError)?),
+                )
+            }
+        };
+
+        Ok(())
+    }
+
+    pub fn into_signed_transaction(self) -> Result<Transaction, ToSignedRecoveryTransactionError> {
+        // TODO: don't like taking the mut Transaction, would rather have optional params to
+        // to_unsigned_transaction to populate witnesses, but I think I want to figure out the
+        // types I'm going to use to represent signatures
+        // would rather centralize info about the transaction structure
+        let mut tx = self.to_unsigned_transaction();
+        match &self.input {
+            RecoveryTransactionInput::VaultOnly(vault, _vout) => {
+                let vault_signature = self.vault_signature
+                    .ok_or(ToSignedRecoveryTransactionError::MissingSignature)?;
+
+                tx.input[0].witness = vault.build_witness(vault_signature);
+
+                Ok(tx)
+            }
+            RecoveryTransactionInput::WithdrawalOnly(withdrawal, _vout) => {
+                let withdrawal_signature = self.withdrawal_signature
+                    .ok_or(ToSignedRecoveryTransactionError::MissingSignature)?;
+
+                tx.input[0].witness = withdrawal.build_witness(withdrawal_signature);
+
+                Ok(tx)
+            }
+            RecoveryTransactionInput::Withdrawal { vault, withdrawal, .. } => {
+                let vault_signature = self.vault_signature
+                    .ok_or(ToSignedRecoveryTransactionError::MissingSignature)?;
+
+                let withdrawal_signature = self.withdrawal_signature
+                    .ok_or(ToSignedRecoveryTransactionError::MissingSignature)?;
+
+                tx.input[0].witness = vault.build_witness(vault_signature);
+                tx.input[1].witness = withdrawal.build_witness(withdrawal_signature);
+
+                Ok(tx)
+            }
+        }
+    }
+}
+
+impl UnderpayingParentTransaction for RecoveryTransaction {
+    fn anchor_outpoint(&self) -> OutPoint {
+        // FIXME: wasteful
+        let tx = self.to_unsigned_transaction();
+        OutPoint {
+            txid: tx.compute_txid(),
+            vout: 1,
+        }
+    }
+
+    fn anchor_output_psbt_input(&self) -> psbt::Input {
+        // FIXME: wasteful
+        let tx = self.to_unsigned_transaction();
+
+        psbt::Input {
+            witness_utxo: Some(ephemeral_anchor()),
+            non_witness_utxo: Some(tx),
+            final_script_witness: Some(Witness::new()),
+            ..Default::default()
+        }
+    }
+
+    fn weight(&self) -> Weight {
+        // FIXME: wasteful
+        let tx = self.to_unsigned_transaction();
+
+        let mut weight = tx.weight() + SEGWIT_MARKER_WEIGHT;
+
+        match &self.input {
+            RecoveryTransactionInput::VaultOnly(vault, _vout) => {
+                let mb_len = vault.control_block.merkle_branch.len();
+                weight += witness_weight(Some((vault.script.len(), mb_len)), &[
+                    SCHNORR_SIGNATURE_SIZE as u64,
+                ]);
+                // Only one input
+                weight += Weight::from_wu_usize(VarInt(1).size());
+            }
+            RecoveryTransactionInput::WithdrawalOnly(withdrawal, _) => {
+                let mb_len = withdrawal.control_block.merkle_branch.len();
+                weight += witness_weight(Some((withdrawal.script.len(), mb_len)), &[
+                    SCHNORR_SIGNATURE_SIZE as u64,
+                ]);
+                // Only one input
+                weight += Weight::from_wu_usize(VarInt(1).size());
+            }
+            RecoveryTransactionInput::Withdrawal { vault, withdrawal, .. } => {
+                let v_mb_len = vault.control_block.merkle_branch.len();
+                weight += witness_weight(Some((vault.script.len(), v_mb_len)), &[
+                    SCHNORR_SIGNATURE_SIZE as u64,
+                ]);
+
+                let w_mb_len = withdrawal.control_block.merkle_branch.len();
+                weight += witness_weight(Some((withdrawal.script.len(), w_mb_len)), &[
+                    SCHNORR_SIGNATURE_SIZE as u64,
+                ]);
+
+                // 2 inputs
+                weight += Weight::from_wu_usize(VarInt(2).size());
+            }
+        }
+
+        weight
+    }
+}
+
+#[derive(Clone,Copy,Debug)]
+pub enum ToSignedRecoveryTransactionError {
+    MissingSignature,
+}
+
+#[derive(Clone,Debug)]
+pub enum SignRecoveryError {
+    SignError(sighash::TaprootError),
+}
+
+impl TailDepositTransactionTemplate {
+    pub fn instantiate(self, vault_prevout: OutPoint, deposit_input_internal_key: XOnlyPublicKey, signing_info: VaultOutputSigningInfo) -> TailDepositTransaction {
+        let common = DepositTransactionCommon::from_template(self.common, deposit_input_internal_key);
+
+        TailDepositTransaction {
+            common,
+            vault_input: TxIn {
+                previous_output: vault_prevout,
+                script_sig: ScriptBuf::new(),
+                sequence: self.vault_input_lock_time.into(),
+                witness: Witness::new(),
+            },
+            signing_info,
+            signature: None,
+        }
+    }
+
+    // TODO: optimize to eliminate the clone
+    fn vault_template_hash(&self) -> sha256::Hash {
+        let tx: Transaction = self.clone().common.to_transaction(
+            Some(dummy_input(self.vault_input_lock_time))
+        );
+
+        get_default_template(&tx, 0)
+    }
+}
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct VaultOutputSigningInfo {
+    pubkey: XOnlyPublicKey,
+    control_block: ControlBlock,
+    vault_prevout: TxOut,
+    //depth: Depth,
+    script: ScriptBuf,
+}
+
+pub type WithdrawalOutputSigningInfo = VaultOutputSigningInfo;
+
+impl VaultOutputSigningInfo {
+    pub fn new(pubkey: XOnlyPublicKey, control_block: ControlBlock, vault_prevout: TxOut, script: ScriptBuf) -> Self {
+        VaultOutputSigningInfo {
+            pubkey,
+            control_block,
+            vault_prevout,
+            script,
+        }
+    }
+
+    fn sign<C: Signing, T: Borrow<TxOut>>(&self, secp: &Secp256k1<C>, keypair: &Keypair, transaction: &Transaction, input_index: usize, prevouts: &sighash::Prevouts<T>) -> Result<taproot::Signature, sighash::TaprootError> {
+        let tap_leaf_hash = TapLeafHash::from_script(self.script.as_ref(), LeafVersion::TapScript);
+        let sighash = sighash::SighashCache::new(transaction)
+            .taproot_signature_hash(input_index, prevouts, None, Some((tap_leaf_hash, 0xFFFFFFFF)), sighash::TapSighashType::Default)?;
+
+        // FIXME: seems like there should be shortcuts for a couple of these things?
+        let message: Message = sighash.into();
+        let signature = secp.sign_schnorr(&message, keypair);
+
+        Ok(taproot::Signature {
+            signature,
+            sighash_type: sighash::TapSighashType::Default,
+        })
+    }
+
+    pub fn build_witness(&self, signature: taproot::Signature) -> Witness {
+        let mut witness = Witness::new();
+        witness.push(signature.to_vec());
+        witness.push(&self.script);
+        witness.push(self.control_block.serialize());
+
+        witness
+    }
+}
+
+pub struct VaultOutputSpendInfo {
+    hot_pubkey: XOnlyPublicKey,
+    #[allow(dead_code)]
+    // Redundant with [`spend_info.internal_key()`] but I prefer to retain the "cold" name to
+    // remember vault semantics
+    cold_pubkey: XOnlyPublicKey,
+    spend_info: TaprootSpendInfo,
+    output: TxOut,
+    #[allow(dead_code)]
+    depth: Depth,
+    branches: HashMap<VaultOutputSpendCondition, SignedNextStateTemplate>,
+}
+
+#[derive(Clone, Copy, Hash, Eq, PartialEq)]
+pub struct SignedNextStateTemplate {
+    pub pubkey: XOnlyPublicKey,
+    pub next_state_template_hash: sha256::Hash,
+}
+
+impl SignedNextStateTemplate {
+    pub fn to_scriptbuf(&self) -> ScriptBuf {
+        // We enforce sequence indirectly via CTV
+        builder_with_capacity(33 + 1 + 1 + 33 + 1)
+            .push_slice(self.next_state_template_hash.to_byte_array())
+            .push_opcode(OP_CHECKTEMPLATEVERIFY)
+            .push_opcode(OP_DROP)
+            .push_x_only_key(&self.pubkey)
+            .push_opcode(OP_CHECKSIG)
+            .into_script()
+    }
+}
+
+impl PartialEq<Script> for SignedNextStateTemplate {
+    fn eq(&self, other: &Script) -> bool {
+        // TODO: Obvious optimization target
+        self.to_scriptbuf().as_script() == other
+    }
+}
+
+#[derive(Clone, Copy, Debug, Hash, Eq, PartialEq)]
+pub enum RecoveryType {
+    VaultOnly,
+    VaultWithWithdrawal,
+}
+
+#[derive(Clone, Copy, Debug, Hash, Eq, PartialEq)]
+pub enum VaultOutputSpendCondition {
+    Deposit(VaultAmount),
+    Withdrawal(VaultAmount),
+    // FIXME: Seems like recovery_type should just be RecoveryDetails with a variant for vault
+    // only, withdrawal only, and both?
+    Recovery {
+        recovery_type: RecoveryType,
+        /// The vault balance prior to this recovery
+        vault_balance: VaultAmount,
+        /// The withdrawal amount prior to this recovery
+        withdrawal_amount: VaultAmount,
+    },
+}
+
+impl VaultOutputSpendInfo {
+    pub fn new<C: Verification>(
+        secp: &Secp256k1<C>,
+        parameters: &VaultParameters,
+        depth: Depth,
+        // XXX: On the fence on just treating an empty vec as None, eliminate the Option
+        spend_conditions: Option<Vec<(VaultOutputSpendCondition, SignedNextStateTemplate)>>,
+        next_value: VaultAmount,
+    ) -> Self {
+        let master_key = parameters.master_key(secp, depth);
+        let cold_pubkey = master_key;
+        let hot_pubkey = parameters.hot_key(secp, depth);
+
+        if let Some(spend_conditions) = spend_conditions {
+            let spend_info = TaprootBuilder::with_huffman_tree(
+                spend_conditions.iter().map(|(condition, script)| (parameters.spend_condition_weight(&condition), script.to_scriptbuf()))
+                )
+                .expect("huffman tree")
+                .finalize(secp, master_key)
+                .expect("finalize");
+
+            let output = TxOut {
+                value: parameters.scale.scale_amount(next_value),
+                script_pubkey: ScriptBuf::new_p2tr_tweaked(spend_info.output_key()),
+            };
+
+            VaultOutputSpendInfo {
+                spend_info,
+                depth,
+                branches: spend_conditions.into_iter().collect(),
+                output,
+                hot_pubkey,
+                cold_pubkey,
+            }
+        } else {
+            // Final state, only spendable by master
+            // TODO: CSFS delegated recursion
+            let script_pubkey = ScriptBuf::new_p2tr(secp, master_key, None);
+
+            VaultOutputSpendInfo {
+                spend_info: TaprootSpendInfo::new_key_spend(secp, master_key, None),
+                depth,
+                branches: iter::empty().collect(),
+                output: TxOut {
+                    value: parameters.scale.scale_amount(next_value),
+                    script_pubkey,
+                },
+                hot_pubkey,
+                cold_pubkey,
+            }
+        }
+    }
+    pub fn to_deposit_common(&self, vault_deposit: VaultAmount, vault_total: VaultAmount, vault_scale: VaultScale) -> DepositTransactionTemplateCommon {
+        DepositTransactionTemplateCommon {
+            depth: self.depth,
+            vault_scale: vault_scale,
+            vault_output: self.output.clone(),
+            vault_deposit,
+            vault_total,
+        }
+    }
+
+    pub fn spend_condition_lookup(&self) -> HashMap<TaprootMerkleBranch, (VaultOutputSpendCondition, SignedNextStateTemplate)> {
+        let spend_conditions = self.branches.iter()
+            .map(|(condition, template)| (template.to_scriptbuf(), (condition, template)))
+            .collect::<HashMap<_, _>>();
+
+        let conditions = |script: &Script| -> Option<(VaultOutputSpendCondition, SignedNextStateTemplate)> {
+            spend_conditions.get(script)
+                .map(|(condition, template)| (**condition, **template))
+        };
+
+        spend_condition_lookup(
+            self.spend_info.script_map()
+                .iter()
+                .map(massage_script_map),
+            conditions,
+        )
+    }
+}
+
+impl OutputSpendingConditions<VaultOutputSpendCondition> for VaultOutputSpendInfo {
+    type SpendingCondition = VaultOutputSigningInfo;
+
+    fn get_spending_condition(&self, selector: VaultOutputSpendCondition) -> Option<Self::SpendingCondition> {
+        let branch = self
+            .branches
+            .get(&selector)?;
+
+        let control_block = self.spend_info.control_block(&(
+            branch.to_scriptbuf(),
+            LeafVersion::TapScript
+        ))?;
+
+        Some(
+            VaultOutputSigningInfo {
+                pubkey: self.hot_pubkey,
+                control_block,
+                vault_prevout: self.output.clone(),
+                script: branch.to_scriptbuf(),
+            }
+        )
+    }
+}

--- a/src/vault.rs
+++ b/src/vault.rs
@@ -2,7 +2,6 @@
 use bdk_bitcoind_rpc::bitcoincore_rpc::{Client, RpcApi, self};
 
 use bitcoin::bip32::{
-    Xpriv,
     Xpub,
     ChildNumber,
     DerivationPath,
@@ -14,26 +13,9 @@ use bitcoin::Block;
 #[cfg(feature = "bitcoind")]
 use bitcoin::consensus::encode::serialize_hex;
 
-use bitcoin::hashes::{
-    Hash,
-    sha256,
-};
-
-use bitcoin::key::TweakedPublicKey;
-use bitcoin::opcodes::all::{
-    OP_CSV,
-    OP_CHECKSIG,
-    OP_NOP4 as OP_CHECKTEMPLATEVERIFY,
-    OP_DROP,
-};
-
 use bitcoin::secp256k1::{
-    constants::SCHNORR_SIGNATURE_SIZE,
-    Keypair,
-    Message,
     PublicKey,
     Secp256k1,
-    Signing,
     Verification,
     XOnlyPublicKey,
 };
@@ -41,9 +23,8 @@ use bitcoin::secp256k1::{
 use bitcoin::taproot::{
     ControlBlock,
     LeafVersion,
-    TaprootBuilder,
     TaprootMerkleBranch,
-    TaprootSpendInfo,
+    TAPROOT_ANNEX_PREFIX,
 };
 
 use bitcoin::{
@@ -51,29 +32,14 @@ use bitcoin::{
     Amount,
     blockdata::locktime::relative,
     blockdata::transaction::Version,
-    BlockHash,
-    FeeRate,
-    key::TapTweak,
     OutPoint,
-    psbt,
     ScriptBuf,
     Script,
-    Sequence,
-    TapLeafHash,
-    TapNodeHash,
     taproot,
-    TapSighashType,
-    transaction,
     Transaction,
     Txid,
     TxIn,
     TxOut,
-    script::Builder,
-    sighash::Prevouts,
-    sighash::SighashCache,
-    sighash,
-    VarInt,
-    Weight,
     Witness,
 };
 
@@ -98,33 +64,63 @@ use serde::{
     Serialize,
 };
 
-use std::borrow::Borrow;
+use std::collections::{hash_map, HashMap, HashSet, BTreeSet, BTreeMap};
 use std::iter;
-
-use std::collections::HashMap;
-use std::ops::{Deref, DerefMut};
+use std::ops::Deref;
+use std::rc::Rc;
 
 use crate::bip119::get_default_template;
 
-use crate::migrate::{
-    configure,
-    migrate,
-    MigrationError,
+use crate::storage::{
+    Change,
+    ChangeLog,
 };
 
-use crate::wallet::{
-    SEGWIT_MARKER_WEIGHT,
-    UnderpayingParentTransaction,
+use crate::cache::{
+    AddTransactionStateCache,
+    VaultTemplateCache,
+};
+
+use crate::transaction::{
+    DepositTransaction,
+    DepositTransactionTemplate,
+    dummy_input,
+    ephemeral_anchor,
+    is_ephemeral_anchor,
+    RecoveryTransaction,
+    RecoveryTransactionInput,
+    RecoveryType,
+    SignedNextStateTemplate,
+    VaultOutputSpendCondition,
+    VaultOutputSpendInfo,
+    VaultTransactionTemplate,
+    WithdrawalOutputSpendInfo,
+    WithdrawalSpendingCondition,
+    WithdrawalTransaction,
+};
+
+use crate::chain::{
+    AddBlockError,
+    AddTransactionError,
+    AddTransactionSuccess,
+    ChainTipState,
+    ConnectTransactionSuccess,
+    ContractInputs,
+    ContractOutputs,
+    ContractTransaction,
+    ContractTransactionConnector,
+    Either,
+    UtxoSelector,
+};
+
+pub use crate::chain::{
+    ContractState,
 };
 
 // struct.unpack(">I", hashlib.sha256(b'mccv').digest()[:4])[0] & 0x7FFFFFFF
 const PURPOSE: u32 = 360843587;
 
 pub type Depth = u32;
-
-fn builder_with_capacity(size: usize) -> Builder {
-    Builder::from(Vec::with_capacity(size))
-}
 
 /// Store XOnlyPublicKey in 32 bytes instead of 64
 ///
@@ -150,14 +146,16 @@ pub enum VaultAmountError {
     OutOfRange,
 }
 
-#[derive(Clone,Copy,Debug,Serialize,Deserialize)]
+#[derive(Clone,Copy,Debug,Eq,PartialEq,Serialize,Deserialize)]
 #[serde(transparent)]
 pub struct VaultScale(u32);
 
 impl VaultScale {
-    pub fn new(scale: u32) -> Self { Self(scale) }
+    pub const fn new(scale: u32) -> Self { Self(scale) }
 
-    pub fn from_sat(scale: u32) -> Self { Self(scale) }
+    pub const fn from_sat(scale: u32) -> Self { Self(scale) }
+
+    pub fn to_sat(&self) -> u32 { self.0 }
 
     pub fn convert_amount(&self, amount: Amount) -> Result<(VaultAmount, Amount), VaultAmountError> {
         let quotient  = amount.to_sat() / (self.0 as u64);
@@ -174,20 +172,20 @@ impl VaultScale {
     }
 }
 
-#[derive(Clone,Serialize,Deserialize)]
+#[derive(Clone, Copy, Debug, Eq, PartialEq, Serialize, Deserialize)]
 pub struct VaultParameters {
-    scale: VaultScale,
+    pub scale: VaultScale,
     /// Maximum value = max * scale
-    max: VaultAmount,
+    pub max: VaultAmount,
     // All coins are always immediately spendable by master_xpub
-    cold_xpub: Xpub,
+    pub cold_xpub: Xpub,
     // Withdrawn coins are spendable by withdrawal_xpub at any time
-    hot_xpub: Xpub,
+    pub hot_xpub: Xpub,
     // Should there be yet another xpub for un-managed funds? probably but not in the vault params
-    delay_per_increment: u32,
-    max_withdrawal_per_step: VaultAmount,
-    max_deposit_per_step: VaultAmount,
-    max_depth: Depth,
+    pub delay_per_increment: u32,
+    pub max_withdrawal_per_step: VaultAmount,
+    pub max_deposit_per_step: VaultAmount,
+    pub max_depth: Depth,
 }
 
 #[derive(Clone,Copy,Debug,Hash,Eq,PartialEq,Serialize,Deserialize)]
@@ -198,9 +196,9 @@ pub struct VaultParameters {
 pub struct VaultAmount(u32);
 
 impl VaultAmount {
-    const ZERO: VaultAmount = VaultAmount(0);
+    pub const ZERO: VaultAmount = VaultAmount(0);
 
-    pub fn new(unscaled_amount: u32) -> Self {
+    pub const fn new(unscaled_amount: u32) -> Self {
         Self(unscaled_amount)
     }
 
@@ -216,7 +214,7 @@ impl VaultAmount {
         self.0.checked_sub(other.0).map(VaultAmount::new)
     }
 
-    fn to_unscaled_amount(&self) -> u32 {
+    pub(crate) fn to_unscaled_amount(&self) -> u32 {
         self.0
     }
 
@@ -283,29 +281,6 @@ impl std::ops::Sub for VaultAmount {
     }
 }
 
-const PAY_TO_ANCHOR_SCRIPT_BYTES: &[u8] = &[0x51, 0x02, 0x4e, 0x73];
-
-fn ephemeral_anchor() -> TxOut {
-    let script_pubkey = ScriptBuf::from_bytes(PAY_TO_ANCHOR_SCRIPT_BYTES.to_vec());
-
-    TxOut {
-        value: Amount::from_sat(0),
-        script_pubkey,
-    }
-}
-
-fn dummy_input(lock_time: relative::LockTime) -> TxIn {
-    TxIn {
-        previous_output: OutPoint {
-            txid: Txid::from_byte_array([0u8; 32]),
-            vout: 0,
-        },
-        script_sig: ScriptBuf::new(),
-        sequence: lock_time.to_sequence(),
-        witness: Witness::new(),
-    }
-}
-
 #[derive(Clone,Copy,Debug,Eq,Hash,PartialEq)]
 pub enum VaultTransition {
     Deposit(VaultAmount),
@@ -313,13 +288,6 @@ pub enum VaultTransition {
 }
 
 impl VaultTransition {
-    fn invert(&self) -> VaultTransition {
-        match self {
-            VaultTransition::Deposit(amount) => VaultTransition::Withdrawal(*amount),
-            VaultTransition::Withdrawal(amount) => VaultTransition::Deposit(*amount),
-        }
-    }
-
     fn to_signed(&self) -> i64 {
         match self {
             VaultTransition::Deposit(value) => i64::from(value.0),
@@ -340,31 +308,27 @@ impl Ord for VaultTransition {
     }
 }
 
-#[derive(Clone,Copy,Debug,Eq,Hash,PartialEq)]
-pub struct VaultStateParameters {
-    //depth: Depth, // Always implicit in the way we process
+#[derive(Clone, Copy, Debug, Eq, Hash, PartialEq)]
+pub(crate) struct VaultStateParameters {
     transition: VaultTransition,
     previous_value: VaultAmount,
     parent_transition: Option<VaultTransition>,
 }
 
 impl VaultStateParameters {
-    fn get_result(&self) -> (VaultAmount, VaultAmount) {
+    pub fn result_value(&self) -> VaultAmount {
         match self.transition {
-            VaultTransition::Deposit(value) => (self.previous_value + value, VaultAmount::ZERO),
-            VaultTransition::Withdrawal(withdrawal_value) =>
-                (self.previous_value - withdrawal_value, withdrawal_value),
+            VaultTransition::Deposit(deposit) => self.previous_value + deposit,
+            VaultTransition::Withdrawal(withdrawal) => self.previous_value - withdrawal,
         }
     }
 
     #[allow(dead_code)]
     fn next(&self, transition: VaultTransition, parameters: &VaultParameters, depth: Depth) -> Option<Self> {
-        let (current_value, _) = self.get_result();
-
         parameters.validate_parameters(
             Self {
                 transition,
-                previous_value: current_value,
+                previous_value: self.result_value(),
                 parent_transition: Some(self.transition),
             },
             depth,
@@ -402,1298 +366,33 @@ impl PartialOrd for VaultStateParameters {
     }
 }
 
-#[derive(Clone,Debug)]
-struct DepositTransactionTemplateCommon {
-    depth: Depth,
-    vault_scale: VaultScale,
-    vault_output: TxOut,
-    vault_deposit: VaultAmount,
-    vault_total: VaultAmount,
+pub(crate) trait OutputSpendingConditions<T> {
+	type SpendingCondition;
+
+    // FIXME: name is sketchy
+	fn get_spending_condition(&self, selector: T) -> Option<Self::SpendingCondition>;
 }
 
-#[derive(Clone,Debug)]
-struct InitialDepositTransactionTemplate {
-    common: DepositTransactionTemplateCommon,
+#[derive(Debug)]
+pub enum GetVaultTemplateError {
+    InvalidVaultDepth,
+    InvalidParameters,
 }
 
-#[derive(Clone,Debug)]
-struct TailDepositTransactionTemplate {
-    common: DepositTransactionTemplateCommon,
-    vault_input_lock_time: relative::LockTime,
-}
-
-#[derive(Clone,Debug)]
-enum DepositTransactionTemplate {
-    InitialDeposit(InitialDepositTransactionTemplate),
-    Deposit(TailDepositTransactionTemplate),
-}
-
-impl DepositTransactionTemplate {
-    fn common(&self) -> &DepositTransactionTemplateCommon {
-        match self {
-            DepositTransactionTemplate::InitialDeposit(deposit) => &deposit.common,
-            DepositTransactionTemplate::Deposit(deposit) => &deposit.common,
-        }
-    }
-}
-
-impl DepositTransactionTemplateCommon {
-    fn into_transaction(self, vault_input: Option<TxIn>) -> Transaction {
-        let input = iter::empty()
-            .chain(Some(dummy_input(relative::LockTime::ZERO)))
-            .chain(vault_input)
-            .collect();
-
-        Transaction {
-            version: transaction::Version::non_standard(3),
-            lock_time: LockTime::ZERO,
-            input,
-            output: vec![self.vault_output],
-        }
-    }
-}
-
-impl InitialDepositTransactionTemplate {
-    fn instantiate(self, deposit_input_internal_key: XOnlyPublicKey) -> InitialDepositTransaction {
-        InitialDepositTransaction {
-            common: DepositTransactionCommon::from_template(self.common, deposit_input_internal_key)
-        }
-    }
-}
-
-impl From<InitialDepositTransactionTemplate> for Transaction {
-    fn from(value: InitialDepositTransactionTemplate) -> Self {
-        value.common.into_transaction(None)
-    }
-}
-
-impl TailDepositTransactionTemplate {
-    fn intantiate(self, vault_prevout: OutPoint, deposit_input_internal_key: XOnlyPublicKey, signing_info: VaultOutputSigningInfo) -> TailDepositTransaction {
-        let common = DepositTransactionCommon::from_template(self.common, deposit_input_internal_key);
-
-        TailDepositTransaction {
-            common,
-            vault_input: TxIn {
-                previous_output: vault_prevout,
-                script_sig: ScriptBuf::new(),
-                sequence: self.vault_input_lock_time.into(),
-                witness: Witness::new(),
-            },
-            signing_info,
-            signature: None,
-        }
-    }
-
-    // TODO: optimize to eliminate the clone
-    fn vault_template_hash(&self) -> sha256::Hash {
-        let tx: Transaction = self.clone().common.into_transaction(
-            Some(dummy_input(self.vault_input_lock_time))
-        );
-
-        get_default_template(&tx, 0)
-    }
-}
-
-#[derive(Clone,Debug)]
-struct DepositTransactionCommon {
-    depth: Depth,
-    vault_scale: VaultScale,
-    vault_deposit: VaultAmount,
-    vault_total: VaultAmount,
-
-    deposit_input_internal_key: XOnlyPublicKey,
-    deposit_input: Option<(TxOut, TxIn)>,
-
-    vault_output: TxOut,
-}
-
-#[derive(Clone,Debug)]
-pub struct InitialDepositTransaction {
-    common: DepositTransactionCommon,
-}
-
-#[derive(Clone,Debug)]
-pub struct TailDepositTransaction {
-    common: DepositTransactionCommon,
-
-    vault_input: TxIn,
-    /// Information required to sign the vault output that this transaction spends
-    signing_info: VaultOutputSigningInfo,
-    signature: Option<taproot::Signature>,
-}
-
-#[derive(Clone,Debug)]
-pub enum DepositTransaction {
-    InitialDeposit(InitialDepositTransaction),
-    Deposit(TailDepositTransaction),
-}
-
-impl DepositTransactionCommon {
-    fn from_template(common: DepositTransactionTemplateCommon, deposit_input_internal_key: XOnlyPublicKey) -> Self {
-        Self {
-            depth: common.depth,
-            deposit_input: None,
-            deposit_input_internal_key,
-            vault_scale: common.vault_scale,
-            vault_output: common.vault_output,
-            vault_deposit: common.vault_deposit,
-            vault_total: common.vault_total,
-        }
-    }
-
-    /// Build a deposit transaction from common elements and an optional vault input
-    ///
-    /// Whether or not the result is signed depends on the state of the deposit input and the
-    /// provided vault_input.
-    fn to_transaction(&self, vault_input: Option<TxIn>) -> Result<Transaction, VaultTransactionBuildError> {
-        let input = iter::empty()
-            .chain(vault_input)
-            .chain(
-                Some(
-                    self.deposit_input.as_ref().map(|(_txout, txin)| txin.clone()).ok_or(VaultTransactionBuildError::MissingInput)?
-                )
-            )
-            .collect();
-
-        Ok(
-            Transaction {
-                version: transaction::Version::non_standard(3),
-                lock_time: LockTime::ZERO,
-                input,
-                output: vec![self.vault_output.clone()],
-            }
-        )
-    }
-
-    fn template_hash(&self, vault_input: Option<TxIn>, input_index: u32) -> sha256::Hash {
-        let input = iter::empty()
-            .chain(vault_input)
-            .chain(Some(dummy_input(relative::LockTime::ZERO)))
-            .collect();
-
-        get_default_template(
-            &Transaction {
-                version: transaction::Version::non_standard(3),
-                lock_time: LockTime::ZERO,
-                input,
-                output: vec![self.vault_output.clone()],
-            },
-            input_index
-        )
-    }
-}
-
-impl TailDepositTransaction {
-    fn vault_template_hash(&self) -> sha256::Hash {
-        get_default_template(
-            &Transaction {
-                version: transaction::Version::non_standard(3),
-                lock_time: LockTime::ZERO,
-                input: vec![
-                    self.vault_input.clone(),
-                    dummy_input(relative::LockTime::ZERO),
-                ],
-                output: vec![self.common.vault_output.clone()],
-            },
-            0,
-        )
-    }
-}
-
-#[derive(Clone,Debug)]
-pub enum VaultTransactionBuildError {
-    // This will always be a deposit input, rename?
-    MissingInput,
-    NotSigned,
-}
-
-impl TryFrom<InitialDepositTransaction> for Transaction {
-    type Error = VaultTransactionBuildError;
-
-    fn try_from(value: InitialDepositTransaction) -> Result<Self, Self::Error> {
-        Ok(
-            Self {
-                version: transaction::Version::non_standard(3),
-                lock_time: LockTime::ZERO,
-                input: vec![
-                    value.common.deposit_input.map(|(_txout, txin)| txin).ok_or(VaultTransactionBuildError::MissingInput)?,
-                ],
-                output: vec![
-                    value.common.vault_output
-                ],
-            }
-        )
-    }
-}
-
-fn witness_item_weight(len: usize) -> Weight {
-    Weight::from_wu_usize(VarInt(len as u64).size() + len)
-}
-
-/// Calculate the serialized length of a single transaction input's witness
-#[allow(dead_code)]
-fn witness_weight(merkle_branches: Option<(usize, usize)>, stack_item_sizes: &[u64]) -> Weight {
-    let extra_stack_item_sizes: &[Weight] = if let Some((script_len, merkle_branches)) = merkle_branches {
-        let cb_length = 33 + 32 * merkle_branches;
-
-        &[
-            witness_item_weight(script_len),
-            witness_item_weight(cb_length),
-        ]
-    } else {
-        &[]
-    };
-
-    let stack_item_count_len = VarInt(
-        stack_item_sizes.len() as u64 +
-        extra_stack_item_sizes.len() as u64
-    ).size();
-
-    stack_item_sizes.iter()
-        .map(|size| witness_item_weight(*size as usize))
-        .chain(extra_stack_item_sizes.into_iter().cloned())
-        .chain(Some(Weight::from_wu_usize(stack_item_count_len)))
-        .sum()
-}
-
-impl DepositTransaction {
-    const DEPOSIT_INPUT_INDEX_INITIAL: usize = 0;
-    const DEPOSIT_INPUT_INDEX_TAIL: usize = 1;
-
-    fn vault_output_info(&self) -> DepositOutputInfo {
-        DepositOutputInfo {
-            deposit_amount: self.common().vault_deposit,
-        }
-    }
-
-    fn vout(&self) -> u32 { self.vault_output_info().vault_vout() }
-
-    fn common(&self) -> &DepositTransactionCommon {
-        match self {
-            DepositTransaction::InitialDeposit(deposit) => &deposit.common,
-            DepositTransaction::Deposit(deposit) => &deposit.common,
-        }
-    }
-
-    fn deposit_witness<C: Verification>(&self, secp: &Secp256k1<C>) -> Witness {
-        let internal_key = self.common().deposit_input_internal_key;
-
-        let script_hash = TapNodeHash::from(self.deposit_script_hash());
-
-        let (_output_key, output_key_parity) = internal_key.tap_tweak(secp, Some(script_hash));
-
-        let mut witness = Witness::new();
-
-        let control_block = ControlBlock {
-            leaf_version: LeafVersion::TapScript,
-            output_key_parity,
-            internal_key,
-            merkle_branch: TaprootMerkleBranch::default(),
-        };
-
-        witness.push(self.deposit_script());
-        witness.push(control_block.serialize());
-
-        witness
-    }
-
-    fn vault_input(&self) -> Option<&TxIn> {
-        match self {
-            DepositTransaction::InitialDeposit(_deposit) => None,
-            DepositTransaction::Deposit(deposit) => Some(&deposit.vault_input),
-        }
-    }
-
-    /// Builds a [`bitcoin::Transaction`] from this [`Self`]
-    ///
-    /// Note that the result transaction may be partially or fully signed.
-    // XXX: Consider renaming to reduce (my own) confusion
-    fn to_unsigned_transaction(&self) -> Result<Transaction, VaultTransactionBuildError> {
-        match self {
-            DepositTransaction::InitialDeposit(deposit) => {
-                deposit.common.to_transaction(None)
-            }
-            DepositTransaction::Deposit(deposit) => {
-                deposit.common.to_transaction(Some(deposit.vault_input.clone()))
-            }
-        }
-    }
-
-    pub fn to_signed_transaction(&self) -> Result<Transaction, VaultTransactionBuildError> {
-        match self {
-            DepositTransaction::InitialDeposit(deposit) => {
-                deposit.common.to_transaction(None)
-            }
-            DepositTransaction::Deposit(deposit) => {
-                if let Some(signature) = deposit.signature {
-                    let mut vault_input = deposit.vault_input.clone();
-                    vault_input.witness = deposit.signing_info.build_witness(signature);
-
-                    deposit.common.to_transaction(Some(vault_input))
-                } else {
-                    Err(VaultTransactionBuildError::NotSigned)
-                }
-            }
-        }
-    }
-
-    // TODO: Estimate weight without constructing the whole transaction
-    pub fn weight<C: Verification>(&self, secp: &Secp256k1<C>) -> Weight {
-        let dummy_deposit = {
-            let mut dummy = dummy_input(relative::LockTime::ZERO);
-
-            dummy.witness = self.deposit_witness(secp);
-
-            dummy
-        };
-
-        let input = match self {
-            DepositTransaction::InitialDeposit(_deposit) => vec![dummy_deposit],
-            DepositTransaction::Deposit(deposit) => {
-                let mut vault_input = deposit.vault_input.clone();
-
-                let dummy_signature = taproot::Signature::from_slice(&[0u8; 64]).expect("valid dummy signature");
-                vault_input.witness = deposit.signing_info.build_witness(dummy_signature);
-
-                vec![vault_input, dummy_deposit]
-            }
-        };
-
-        let tx = Transaction {
-            version: transaction::Version::non_standard(3),
-            lock_time: LockTime::ZERO,
-            input,
-            output: vec![self.common().vault_output.clone()],
-        };
-
-        tx.weight()
-    }
-
-    /// Generates the template hash for the deposit (shape/prepare) transaction input
-    fn deposit_template_hash(&self) -> sha256::Hash {
-        let deposit_input_index = match self {
-            DepositTransaction::InitialDeposit(_) => Self::DEPOSIT_INPUT_INDEX_INITIAL,
-            DepositTransaction::Deposit(_) => Self::DEPOSIT_INPUT_INDEX_TAIL,
-        };
-
-        self.common().template_hash(
-            self.vault_input().cloned(),
-            deposit_input_index as u32,
-        )
-    }
-
-    fn deposit_script(&self) -> ScriptBuf {
-        let template_hash = self.deposit_template_hash();
-
-        builder_with_capacity(33 + 1 + 1 + 33 + 1)
-            .push_slice(template_hash.to_byte_array())
-            .push_opcode(OP_CHECKTEMPLATEVERIFY)
-            .into_script()
-    }
-
-    // TODO: low priority: optimize without constructing Transaction
-    fn compute_txid(&self) -> Result<Txid, VaultTransactionBuildError> {
-        let tx: Transaction = self.to_unsigned_transaction()?;
-
-        Ok(tx.compute_txid())
-    }
+pub(crate) trait VaultTemplates {
+    type Templates: Deref<Target = VaultGeneration>;
 
     #[allow(dead_code)]
-    // This will be used directly once I defer generation of the deposit input witness
-    fn deposit_script_hash(&self) -> TapLeafHash {
-        let script = self.deposit_script();
+    fn get<C: Verification>(&self, secp: &Secp256k1<C>, depth: Depth, parameters: &VaultStateParameters) -> Result<VaultTransactionTemplate, GetVaultTemplateError>;
 
-        TapLeafHash::from_script(
-            script.as_script(),
-            LeafVersion::TapScript,
-        )
-    }
-
-    // TODO: Devise a better API
-    pub fn hot_keypair<C: Signing>(&self, secp: &Secp256k1<C>, xpriv: &Xpriv) -> Result<Keypair, KeypairDerivationError> {
-        match self {
-            DepositTransaction::InitialDeposit(_) => Err(KeypairDerivationError::NoSigningInfo),
-            DepositTransaction::Deposit(deposit) => {
-                let parent_depth = deposit.common.depth - 1;
-                let keypair = xpriv.derive_priv(secp, &[
-                    ChildNumber::from_normal_idx(parent_depth as u32)
-                        .expect("assume sane child number")
-                ])
-                .map(|xpriv| xpriv.to_keypair(secp))
-                .map_err(|e| {
-                    match e {
-                        bitcoin::bip32::Error::MaximumDepthExceeded => KeypairDerivationError::DerivationDepthExceeded,
-                        _ => unreachable!("Xpriv derivation can only fail with maximum depth"),
-                    }
-                })?;
-
-                if deposit.signing_info.pubkey != keypair.x_only_public_key().0 {
-                    Err(KeypairDerivationError::WrongKey)
-                } else {
-                    Ok(keypair)
-                }
-            }
-        }
-    }
-
-    // TODO: make it simple for the caller to lookup the correct keys
-    pub fn sign_vault_input<C: Signing>(&mut self, secp: &Secp256k1<C>, keys: &Keypair) -> Result<(), DepositSignError> {
-        // Had to hoist the into_unsigned_transaction() here because 'self' is already mutably
-        // borrowed in the match. Annoying, clean this up later.
-        let transaction = self.to_unsigned_transaction()
-            .map_err(|e| {
-                match e {
-                    VaultTransactionBuildError::MissingInput => DepositSignError::NoShapeTransaction,
-                    // FIXME: not in love with having yet another panic location
-                    VaultTransactionBuildError::NotSigned => unreachable!("to_unsigned_transaction() won't produce this error"),
-                }
-            })?;
-
-        match self {
-            DepositTransaction::InitialDeposit(_) => Ok(()),
-            // Previous version returned Err(DepositSignError::NoSignatureNeeded)
-            // do we care? should we care? I'm inclined to let it go silently...
-            DepositTransaction::Deposit(ref mut deposit) => {
-                let prevout_txouts = vec![
-                    &deposit.signing_info.vault_prevout,
-                    deposit.common.deposit_input
-                        .as_ref()
-                        .map(|(txout, _txin)| txout)
-                        .ok_or(DepositSignError::NoShapeTransaction)?
-                ];
-
-                let prevouts = Prevouts::All(&prevout_txouts);
-
-                deposit.signature = Some(deposit.signing_info.sign(secp, keys, &transaction, 0, &prevouts)
-                    .map_err(|e| DepositSignError::SighashError(e))?
-                );
-
-                Ok(())
-            }
-        }
-    }
-
-    pub fn payment_info<C: Verification>(&self, secp: &Secp256k1<C>) -> (ScriptBuf, Amount) {
-        let pubkey = self.common().deposit_input_internal_key;
-        let scale = self.common().vault_scale;
-        let amount = scale.scale_amount(self.common().vault_deposit);
-        let script_hash = TapNodeHash::from(self.deposit_script_hash());
-        let script_pubkey = ScriptBuf::new_p2tr(secp, pubkey, Some(script_hash));
-
-        (script_pubkey, amount)
-    }
-
-    pub fn connect_input<C: Verification>(&mut self, secp: &Secp256k1<C>, previous_output: OutPoint, txout: TxOut) {
-        let deposit_input = TxIn {
-            previous_output,
-            script_sig: ScriptBuf::new(),
-            sequence: Sequence::ZERO,
-            witness: self.deposit_witness(secp),
-        };
-
-        match self {
-            DepositTransaction::InitialDeposit(ref mut deposit) => {
-                deposit.common.deposit_input = Some((txout, deposit_input));
-            }
-            DepositTransaction::Deposit(ref mut deposit) => {
-                deposit.common.deposit_input = Some((txout, deposit_input));
-            }
-        }
-    }
+    fn get_generation<C: Verification>(&self, secp: &Secp256k1<C>, depth: Depth) -> Option<Self::Templates>;
 }
 
-#[derive(Clone,Copy,Debug)]
-struct DepositOutputInfo {
-    deposit_amount: VaultAmount,
-}
-
-impl DepositOutputInfo {
-    fn vault_vout(&self) -> u32 { 0 }
-
-    fn to_vault_history_transaction_details(&self) -> VaultHistoryTransactionDetails {
-        VaultHistoryTransactionDetails::VaultDeposit {
-            deposit_amount: self.deposit_amount,
-            vout: self.vault_vout(),
-        }
-    }
-}
-
-#[derive(Clone,Copy,Debug)]
-struct WithdrawalOutputInfo {
-    vault_result_value: VaultAmount,
-    withdrawal_amount: VaultAmount,
-}
-
-// TODO: Centralize knowledge of the vouts here
-impl WithdrawalOutputInfo {
-    fn vault_vout(&self) -> Option<u32> {
-        if self.vault_result_value > VaultAmount::ZERO {
-            Some(0)
-        } else {
-            None
-        }
-    }
-
-    fn withdrawal_vout(&self) -> u32 {
-        if self.vault_result_value > VaultAmount::ZERO {
-            1
-        } else {
-            0
-        }
-    }
-
-    fn to_vault_history_transaction_details(&self) -> VaultHistoryTransactionDetails {
-        VaultHistoryTransactionDetails::VaultWithdrawal {
-            withdrawal_amount: self.withdrawal_amount,
-            vault_vout: self.vault_vout(),
-            withdrawal_vout: self.withdrawal_vout(),
-        }
-    }
-}
-
-#[derive(Clone,Debug)]
-struct WithdrawalTransactionTemplate {
-    depth: Depth,
-    vault_input_lock_time: relative::LockTime,
-    vault_output: Option<TxOut>,
-    withdrawal_output: TxOut,
-
-    vault_total: VaultAmount,
-    vault_withdrawal: VaultAmount,
-}
-
-impl WithdrawalTransactionTemplate {
-    fn instantiate(&self, vault_prevout: OutPoint, signing_info: VaultOutputSigningInfo, withdrawal_output_info: WithdrawalOutputSpendInfo) -> WithdrawalTransaction {
-        let vault_input = TxIn {
-            previous_output: vault_prevout,
-            script_sig: ScriptBuf::new(),
-            sequence: self.vault_input_lock_time.into(),
-            witness: Witness::new(),
-        };
-
-        WithdrawalTransaction {
-            depth: self.depth,
-            vault_total: self.vault_total,
-            vault_withdrawal: self.vault_withdrawal,
-            signing_info,
-            vault_input,
-            vault_signature: None,
-            vault_output: self.vault_output.clone(),
-            withdrawal_output: self.withdrawal_output.clone(),
-            withdrawal_output_info,
-        }
-    }
-
-    // TODO: implement optimized version without constructing the Transaction
-    fn vault_template_hash(&self) -> sha256::Hash {
-        let output = iter::empty()
-            // Vault output
-            .chain(self.vault_output.clone())
-            .chain(Some(self.withdrawal_output.clone()))
-            .chain(Some(ephemeral_anchor()))
-            .collect();
-
-        let tx = Transaction {
-            version: transaction::Version::non_standard(3),
-            lock_time: LockTime::ZERO,
-            input: vec![dummy_input(self.vault_input_lock_time)],
-            output,
-        };
-
-        get_default_template(&tx, 0)
-    }
-}
-
-#[derive(Clone,Debug)]
-struct WithdrawalOutputSpendInfo {
-    timelock: relative::LockTime,
-    single_recovery_script: ScriptBuf,
-    double_recovery_script: Option<ScriptBuf>,
-    timelocked_withdrawal_script: ScriptBuf,
-    hot_pubkey: XOnlyPublicKey,
-    master_pubkey: XOnlyPublicKey,
-}
-
-impl WithdrawalOutputSpendInfo {
-    fn recovery_node_hash(&self) -> TapNodeHash {
-        let single = TapNodeHash::from_script(self.single_recovery_script.as_script(), LeafVersion::TapScript);
-
-        if let Some(ref double) = self.double_recovery_script {
-            let double = TapNodeHash::from_script(double.as_script(), LeafVersion::TapScript);
-            TapNodeHash::from_node_hashes(single, double)
-        } else {
-            single
-        }
-    }
-
-    fn root_node_hash(&self) -> TapNodeHash {
-        let recovery = self.recovery_node_hash();
-
-        let timelocked_withdrawal = TapNodeHash::from_script(self.timelocked_withdrawal_script.as_script(), LeafVersion::TapScript);
-
-        TapNodeHash::from_node_hashes(recovery, timelocked_withdrawal)
-    }
-
-    fn script_pubkey<C: Verification>(&self, secp: &Secp256k1<C>) -> ScriptBuf {
-        let root_node_hash = self.root_node_hash();
-        ScriptBuf::new_p2tr(secp, self.master_pubkey, Some(root_node_hash))
-    }
-
-    fn timelocked_withdrawal_merkle_branch(&self) -> TaprootMerkleBranch {
-        [self.recovery_node_hash()].try_into()
-            .expect("single branch cannot overflow max depth")
-    }
-
-    fn recovery_merkle_branch(&self) -> TaprootMerkleBranch {
-        if self.double_recovery_script.is_some() {
-            [
-                TapNodeHash::from_script(self.single_recovery_script.as_script(), LeafVersion::TapScript),
-                TapNodeHash::from_script(self.timelocked_withdrawal_script.as_script(), LeafVersion::TapScript),
-            ]
-            .try_into()
-            .expect("cannot overflow max depth")
-        } else {
-            [TapNodeHash::from_script(self.timelocked_withdrawal_script.as_script(), LeafVersion::TapScript)].try_into()
-            .expect("cannot overflow max depth")
-        }
-    }
-}
-
-#[derive(Clone,Debug)]
-pub struct WithdrawalTransaction {
-    depth: Depth,
-    vault_input: TxIn,
-    vault_signature: Option<taproot::Signature>,
-    vault_output: Option<TxOut>,
-    withdrawal_output: TxOut,
-
-    vault_total: VaultAmount,
-    vault_withdrawal: VaultAmount,
-
-    withdrawal_output_info: WithdrawalOutputSpendInfo,
-
-    /// Information required to sign the vault output that this transaction spends
-    signing_info: VaultOutputSigningInfo,
-}
-
-impl WithdrawalTransaction {
-    fn output_info(&self) -> WithdrawalOutputInfo {
-        WithdrawalOutputInfo {
-            vault_result_value: self.vault_total,
-            withdrawal_amount: self.vault_withdrawal,
-        }
-    }
-
-    fn vault_vout(&self) -> Option<u32> { self.output_info().vault_vout() }
-
-    fn withdrawal_vout(&self) -> u32 { self.output_info().withdrawal_vout() }
-
-    fn into_transaction(self) -> Transaction {
-        let output = iter::empty()
-            .chain(self.vault_output)
-            .chain(Some(self.withdrawal_output))
-            .chain(Some(ephemeral_anchor()))
-            .collect();
-
-        Transaction {
-            version: transaction::Version::non_standard(3),
-            lock_time: LockTime::ZERO,
-            input: vec![self.vault_input],
-            output,
-        }
-    }
-
-    // TODO: eliminate need to construct transaction
-    fn compute_txid(&self) -> Txid {
-        let tx: Transaction = self.clone().into_transaction();
-
-        tx.compute_txid()
-    }
-
-    pub fn anchor_outpoint(&self) -> OutPoint {
-        OutPoint {
-            txid: self.compute_txid(),
-            vout: if self.vault_output.is_some() {
-                2
-            } else {
-                1
-            },
-        }
-    }
-
-    pub fn anchor_output_psbt_input(&self) -> psbt::Input {
-        psbt::Input {
-            witness_utxo: Some(ephemeral_anchor()),
-            non_witness_utxo: Some(self.clone().into_transaction()),
-            final_script_witness: Some(Witness::new()),
-            ..Default::default()
-        }
-    }
-
-    pub fn hot_keypair<C: Signing>(&self, secp: &Secp256k1<C>, xpriv: &Xpriv) -> Result<Keypair, KeypairDerivationError> {
-        let parent_depth = self.depth - 1;
-        let keypair = xpriv.derive_priv(secp, &[
-            ChildNumber::from_normal_idx(parent_depth as u32)
-                .expect("sane child number")
-        ])
-        .map(|xpriv| xpriv.to_keypair(secp))
-        .map_err(|e| {
-            match e {
-                bitcoin::bip32::Error::MaximumDepthExceeded => KeypairDerivationError::DerivationDepthExceeded,
-                _ => unreachable!("Xpriv derivation can only fail with maximum depth"),
-            }
-        })?;
-
-        if self.signing_info.pubkey != keypair.x_only_public_key().0 {
-            Err(KeypairDerivationError::WrongKey)
-        } else {
-            Ok(keypair)
-        }
-    }
-
-    // FIXME: Result instead of Option?
-    pub fn to_signed_transaction(&self) -> Option<Transaction> {
-        let mut vault_input = self.vault_input.clone();
-        vault_input.witness = self.signing_info.build_witness(self.vault_signature?);
-
-        let output = iter::empty()
-            .chain(self.vault_output.clone())
-            .chain(Some(self.withdrawal_output.clone()))
-            .chain(Some(ephemeral_anchor()))
-            .collect();
-
-        Some(
-            Transaction {
-                version: transaction::Version::non_standard(3),
-                lock_time: LockTime::ZERO,
-                input: vec![vault_input],
-                output,
-            }
-        )
-    }
-
-    pub fn spend_withdrawal(self) -> WithdrawalSpendTransaction {
-        WithdrawalSpendTransaction {
-            depth: self.depth,
-            prevout: OutPoint {
-                txid: self.compute_txid(),
-                vout: if self.vault_output.is_some() {
-                    1
-                } else {
-                    0
-                },
-            },
-            withdrawal_output: self.withdrawal_output,
-            withdrawal_output_info: self.withdrawal_output_info,
-        }
-    }
-
-    pub fn weight(&self) -> Weight {
-        let serialized_schnorr_sig_len = VarInt(SCHNORR_SIGNATURE_SIZE as u64).size() as u64 + SCHNORR_SIGNATURE_SIZE as u64;
-        let script_len = self.signing_info.script.len() as u64;
-        let serialized_script_len = VarInt(script_len).size() as u64 + script_len;
-        let control_block_len = self.signing_info.control_block.size() as u64;
-        let serialized_control_block_len = VarInt(control_block_len).size() as u64 + control_block_len;
-
-        self.clone().into_transaction().weight() +
-            if self.vault_signature.is_some() {
-                // We've already been signed, rust-bitcoin will
-                // calculate the correct weight
-                Weight::ZERO
-            } else {
-                Weight::from_wu(
-                    2 + 1 + // Segwit marker + witness item count
-                    serialized_schnorr_sig_len +
-                    serialized_script_len +
-                    serialized_control_block_len
-                )
-            }
-    }
-
-    pub fn sign_vault_input<C: Signing>(&mut self, secp: &Secp256k1<C>, keypair: &Keypair) -> Result<(), WithdrawalSignError> {
-        let prevout_txouts = vec![
-            &self.signing_info.vault_prevout,
-        ];
-
-        // TODO: also check that we actually satisfy the script, probably facilitated by hanging
-        // onto the script template instead of the serialized ScriptBuf
-        let prevouts = Prevouts::All(&prevout_txouts);
-
-        let transaction = self.clone().into_transaction();
-
-        let signature = self.signing_info.sign(secp, keypair, &transaction, 0, &prevouts)
-            .map_err(|e| WithdrawalSignError::SighashError(e))?;
-
-        self.vault_signature = Some(signature);
-
-        Ok(())
-    }
-}
-
-#[derive(Clone,Debug)]
-pub enum WithdrawalSpendError {
-    FeeTooLarge,
-    SighashError(sighash::TaprootError),
-    FeeOverflow,
-}
-
-#[derive(Clone,Debug)]
-pub struct WithdrawalSpendTransaction {
-    depth: Depth,
-    prevout: OutPoint,
-    withdrawal_output: TxOut,
-    withdrawal_output_info: WithdrawalOutputSpendInfo,
-}
-
-impl WithdrawalSpendTransaction {
-    pub fn timelock(&self) -> relative::LockTime {
-        self.withdrawal_output_info.timelock
-    }
-
-    pub fn hot_keypair<C: Signing>(&self, secp: &Secp256k1<C>, xpriv: &Xpriv) -> Result<Keypair, KeypairDerivationError> {
-        let keypair = xpriv.derive_priv(secp, &[
-            ChildNumber::from_normal_idx(self.depth as u32)
-                .expect("sane child number")
-        ])
-        .map(|xpriv| xpriv.to_keypair(secp))
-        .map_err(|e| {
-            match e {
-                bitcoin::bip32::Error::MaximumDepthExceeded => KeypairDerivationError::DerivationDepthExceeded,
-                _ => unreachable!("Xpriv derivation can only fail with maximum depth"),
-            }
-        })?;
-
-        if self.withdrawal_output_info.hot_pubkey != keypair.x_only_public_key().0 {
-            Err(KeypairDerivationError::WrongKey)
-        } else {
-            Ok(keypair)
-        }
-    }
-
-    pub fn spend<C: Signing + Verification>(&self, secp: &Secp256k1<C>, keypair: &Keypair, script_pubkey: ScriptBuf, min_fee: Amount, min_fee_rate: FeeRate) -> Result<Transaction, WithdrawalSpendError> {
-        let mut transaction = Transaction {
-            version: transaction::Version::TWO,
-            lock_time: LockTime::ZERO,
-            input: vec![
-                TxIn {
-                    previous_output: self.prevout,
-                    script_sig: ScriptBuf::new(),
-                    sequence: self.withdrawal_output_info.timelock.into(),
-                    witness: Witness::new(),
-                },
-            ],
-            output: vec![
-                TxOut {
-                    value: self.withdrawal_output.value - min_fee,
-                    script_pubkey,
-                }
-            ],
-        };
-
-        if min_fee > self.withdrawal_output.value {
-            return Err(WithdrawalSpendError::FeeTooLarge);
-        }
-
-        let tap_leaf_hash = TapLeafHash::from_script(
-            self
-                .withdrawal_output_info
-                .timelocked_withdrawal_script
-                .as_script(),
-            LeafVersion::TapScript,
-        );
-
-        let tap_node_hash = self.withdrawal_output_info.root_node_hash();
-
-        let (_output_key, output_key_parity) = self.withdrawal_output_info.master_pubkey.tap_tweak(secp, Some(tap_node_hash));
-
-        let control_block = ControlBlock {
-            leaf_version: LeafVersion::TapScript,
-            output_key_parity,
-            internal_key: self.withdrawal_output_info.master_pubkey,
-            merkle_branch: self.withdrawal_output_info.timelocked_withdrawal_merkle_branch(),
-        };
-
-        let script_len = self.withdrawal_output_info.timelocked_withdrawal_script.len();
-        let control_block_len = control_block.size();
-
-        let weight = transaction.weight()
-            + SEGWIT_MARKER_WEIGHT
-            + Weight::from_wu(VarInt(3).size() as u64) // 3 witness items
-            + Weight::from_wu(VarInt(SCHNORR_SIGNATURE_SIZE as u64).size() as u64)
-            + Weight::from_wu(SCHNORR_SIGNATURE_SIZE as u64)
-            + Weight::from_wu(VarInt(script_len as u64).size() as u64)
-            + Weight::from_wu(script_len as u64)
-            + Weight::from_wu(VarInt(control_block_len as u64).size() as u64)
-            + Weight::from_wu(control_block_len as u64);
-
-        let fee = min_fee_rate.checked_mul_by_weight(weight)
-            .ok_or(WithdrawalSpendError::FeeOverflow)?;
-
-        let fee = std::cmp::max(min_fee, fee);
-
-        transaction.output[0].value = self.withdrawal_output.value - fee;
-
-        let prevout_txouts = vec![
-            &self.withdrawal_output,
-        ];
-
-        let prevouts = Prevouts::All(&prevout_txouts);
-
-        let sighash = SighashCache::new(&transaction)
-            .taproot_signature_hash(0, &prevouts, None, Some((tap_leaf_hash, 0xFFFFFFFF)), TapSighashType::Default)
-            .map_err(|e| WithdrawalSpendError::SighashError(e))?;
-
-        // FIXME: seems like there should be shortcuts for a couple of these things?
-        let message: Message = sighash.into();
-        let signature = secp.sign_schnorr(&message, keypair);
-
-        let signature = taproot::Signature {
-            signature,
-            sighash_type: TapSighashType::Default,
-        };
-
-        transaction.input[0].witness.push(signature.serialize());
-        transaction.input[0].witness.push(
-            self
-                .withdrawal_output_info
-                .timelocked_withdrawal_script
-                .as_bytes()
-        );
-        transaction.input[0].witness.push(control_block.serialize());
-
-        Ok(transaction)
-    }
-}
-
-#[derive(Clone,Debug)]
-enum RecoveryTransactionInput {
-    /// Deposit or Withdrawal vault output without withdrawal output
-    /// u32 is the vault output
-    VaultOnly(VaultOutputSigningInfo, u32),
-    // u32 is the vout, it can vary depending on whether the withdrawal
-    // had a vault output or not.
-    WithdrawalOnly(WithdrawalOutputSigningInfo, u32),
-    Withdrawal {
-        vault: VaultOutputSigningInfo,
-        vault_vout: u32,
-        withdrawal: WithdrawalOutputSigningInfo,
-        withdrawal_vout: u32,
-    },
-}
-
-#[derive(Clone,Debug)]
-pub struct RecoveryTransaction {
-    depth: Depth,
-
-    prevout_txid: Txid,
-    input: RecoveryTransactionInput,
-
-    output: TxOut,
-
-    // FIXME: pretty goofy, should probably use an enum parallel to RecoveryTransactionSigningInfo
-    vault_signature: Option<taproot::Signature>,
-    withdrawal_signature: Option<taproot::Signature>,
-}
-
-#[derive(Clone,Copy,Debug)]
-pub enum ToSignedRecoveryTransactionError {
-    MissingSignature,
-}
-
-#[derive(Clone,Debug)]
-pub enum SignRecoveryError {
-    SignError(sighash::TaprootError),
-}
-
-impl RecoveryTransaction {
-    fn to_unsigned_transaction(&self) -> Transaction {
-        let input = match &self.input {
-            RecoveryTransactionInput::VaultOnly(_vault, vault_vout) => vec![
-                TxIn {
-                    previous_output: OutPoint {
-                        txid: self.prevout_txid,
-                        vout: *vault_vout,
-                    },
-                    script_sig: ScriptBuf::new(),
-                    sequence: Sequence::ZERO,
-                    witness: Witness::new(),
-                },
-
-            ],
-            RecoveryTransactionInput::WithdrawalOnly(_withdrawal, vout) => vec![
-                TxIn {
-                    previous_output: OutPoint {
-                        txid: self.prevout_txid,
-                        vout: *vout,
-                    },
-                    script_sig: ScriptBuf::new(),
-                    sequence: Sequence::ZERO,
-                    witness: Witness::new(),
-                },
-            ],
-            RecoveryTransactionInput::Withdrawal { vault_vout, withdrawal_vout, .. } => vec![
-                TxIn {
-                    previous_output: OutPoint {
-                        txid: self.prevout_txid,
-                        vout: *vault_vout,
-                    },
-                    script_sig: ScriptBuf::new(),
-                    sequence: Sequence::ZERO,
-                    witness: Witness::new(),
-                },
-                TxIn {
-                    previous_output: OutPoint {
-                        txid: self.prevout_txid,
-                        vout: *withdrawal_vout,
-                    },
-                    script_sig: ScriptBuf::new(),
-                    sequence: Sequence::ZERO,
-                    witness: Witness::new(),
-                },
-            ],
-        };
-
-        let output = vec![
-            self.output.clone(),
-            ephemeral_anchor(),
-        ];
-
-        Transaction {
-            version: transaction::Version::non_standard(3),
-            lock_time: LockTime::ZERO,
-            input,
-            output,
-        }
-    }
-
-    // TODO: Devise a better API
-    pub fn hot_keypair<C: Signing>(&self, secp: &Secp256k1<C>, xpriv: &Xpriv) -> Result<Keypair, KeypairDerivationError> {
-        let parent_depth = self.depth - 1;
-
-        let keypair = xpriv.derive_priv(secp, &[
-            ChildNumber::from_normal_idx(parent_depth as u32)
-                .expect("assume sane child number")
-        ])
-        .map(|xpriv| xpriv.to_keypair(secp))
-        .map_err(|e| {
-            match e {
-                bitcoin::bip32::Error::MaximumDepthExceeded => KeypairDerivationError::DerivationDepthExceeded,
-                _ => unreachable!("Xpriv derivation can only fail with maximum depth"),
-            }
-        })?;
-
-        // TODO: Validate derived key's pubkey
-        Ok(keypair)
-    }
-
-    pub fn sign<C: Signing>(&mut self, secp: &Secp256k1<C>, keypair: &Keypair) -> Result<(), SignRecoveryError> {
-        let inputs = match &self.input {
-            RecoveryTransactionInput::VaultOnly(vault, _vout) =>
-                vec![&vault.vault_prevout],
-            RecoveryTransactionInput::WithdrawalOnly(withdrawal, _vout) =>
-                vec![&withdrawal.vault_prevout],
-            RecoveryTransactionInput::Withdrawal { vault, withdrawal, .. } =>
-                vec![
-                    &vault.vault_prevout,
-                    // FIXME: Slightly poorly named here, this is the withdrawal prevout...
-                    // Maybe VaultOutputSigningInfo should be renamed...
-                    // The key in this case is that it has the signing info we need
-                    &withdrawal.vault_prevout,
-                ],
-        };
-
-        let prevouts = Prevouts::All(&inputs);
-
-        let transaction = self.to_unsigned_transaction();
-
-        (self.vault_signature, self.withdrawal_signature) = match &self.input {
-            RecoveryTransactionInput::VaultOnly(vault, _vout) => {
-                (
-                    Some(vault.sign(secp, keypair, &transaction, 0, &prevouts).map_err(SignRecoveryError::SignError)?),
-                    None,
-                )
-            }
-            RecoveryTransactionInput::WithdrawalOnly(withdrawal, _vout) => {
-                (
-                    None,
-                    Some(withdrawal.sign(secp, keypair, &transaction, 1, &prevouts).map_err(SignRecoveryError::SignError)?),
-                )
-            }
-            RecoveryTransactionInput::Withdrawal { vault, withdrawal, .. } => {
-                // FIXME: vault input indices hard coded, not a huge deal but I just went on a
-                // rampage against hard coded vouts
-                (
-                    Some(vault.sign(secp, keypair, &transaction, 0, &prevouts).map_err(SignRecoveryError::SignError)?),
-                    Some(withdrawal.sign(secp, keypair, &transaction, 1, &prevouts).map_err(SignRecoveryError::SignError)?),
-                )
-            }
-        };
-
-        Ok(())
-    }
-
-    pub fn into_signed_transaction(self) -> Result<Transaction, ToSignedRecoveryTransactionError> {
-        // FIXME: don't like taking the mut Transaction, would rather have optional params to
-        // to_unsigned_transaction to populate witnesses, but I think I want to figure out the
-        // types I'm going to use to represent signatures
-        // would rather centralize info about the transaction structure
-        let mut tx = self.to_unsigned_transaction();
-        match &self.input {
-            RecoveryTransactionInput::VaultOnly(vault, _vout) => {
-                let vault_signature = self.vault_signature
-                    .ok_or(ToSignedRecoveryTransactionError::MissingSignature)?;
-
-                tx.input[0].witness = vault.build_witness(vault_signature);
-
-                Ok(tx)
-            }
-            RecoveryTransactionInput::WithdrawalOnly(withdrawal, _vout) => {
-                let withdrawal_signature = self.withdrawal_signature
-                    .ok_or(ToSignedRecoveryTransactionError::MissingSignature)?;
-
-                tx.input[0].witness = withdrawal.build_witness(withdrawal_signature);
-
-                Ok(tx)
-            }
-            RecoveryTransactionInput::Withdrawal { vault, withdrawal, .. } => {
-                let vault_signature = self.vault_signature
-                    .ok_or(ToSignedRecoveryTransactionError::MissingSignature)?;
-
-                let withdrawal_signature = self.withdrawal_signature
-                    .ok_or(ToSignedRecoveryTransactionError::MissingSignature)?;
-
-                tx.input[0].witness = vault.build_witness(vault_signature);
-                tx.input[1].witness = withdrawal.build_witness(withdrawal_signature);
-
-                Ok(tx)
-            }
-        }
-    }
-}
-
-impl UnderpayingParentTransaction for RecoveryTransaction {
-    fn anchor_outpoint(&self) -> OutPoint {
-        // FIXME: wasteful
-        let tx = self.to_unsigned_transaction();
-        OutPoint {
-            txid: tx.compute_txid(),
-            vout: 1,
-        }
-    }
-
-    fn anchor_output_psbt_input(&self) -> psbt::Input {
-        // FIXME: wasteful
-        let tx = self.to_unsigned_transaction();
-
-        psbt::Input {
-            witness_utxo: Some(ephemeral_anchor()),
-            non_witness_utxo: Some(tx),
-            final_script_witness: Some(Witness::new()),
-            ..Default::default()
-        }
-    }
-
-    fn weight(&self) -> Weight {
-        // FIXME: wasteful
-        let tx = self.to_unsigned_transaction();
-
-        let mut weight = tx.weight() + SEGWIT_MARKER_WEIGHT;
-
-        match &self.input {
-            RecoveryTransactionInput::VaultOnly(vault, _vout) => {
-                let mb_len = vault.control_block.merkle_branch.len();
-                weight += witness_weight(Some((vault.script.len(), mb_len)), &[
-                    SCHNORR_SIGNATURE_SIZE as u64,
-                ]);
-                // Only one input
-                weight += Weight::from_wu_usize(VarInt(1).size());
-            }
-            RecoveryTransactionInput::WithdrawalOnly(withdrawal, _) => {
-                let mb_len = withdrawal.control_block.merkle_branch.len();
-                weight += witness_weight(Some((withdrawal.script.len(), mb_len)), &[
-                    SCHNORR_SIGNATURE_SIZE as u64,
-                ]);
-                // Only one input
-                weight += Weight::from_wu_usize(VarInt(1).size());
-            }
-            RecoveryTransactionInput::Withdrawal { vault, withdrawal, .. } => {
-                let v_mb_len = vault.control_block.merkle_branch.len();
-                weight += witness_weight(Some((vault.script.len(), v_mb_len)), &[
-                    SCHNORR_SIGNATURE_SIZE as u64,
-                ]);
-
-                let w_mb_len = withdrawal.control_block.merkle_branch.len();
-                weight += witness_weight(Some((withdrawal.script.len(), w_mb_len)), &[
-                    SCHNORR_SIGNATURE_SIZE as u64,
-                ]);
-
-                // 2 inputs
-                weight += Weight::from_wu_usize(VarInt(2).size());
-            }
-        }
-
-        weight
-    }
-}
-
-#[derive(Clone,Debug)]
-enum VaultTransactionTemplate {
-    Deposit(DepositTransactionTemplate),
-    Withdrawal(WithdrawalTransactionTemplate),
-}
-
-impl VaultTransactionTemplate {
-    fn vault_template_hash(&self) -> sha256::Hash {
-        match self {
-            VaultTransactionTemplate::Deposit(DepositTransactionTemplate::InitialDeposit(_deposit)) => unreachable!("initial deposit can't be the destination of a vault output"),
-            VaultTransactionTemplate::Deposit(DepositTransactionTemplate::Deposit(deposit)) => deposit.vault_template_hash(),
-            VaultTransactionTemplate::Withdrawal(withdrawal) => withdrawal.vault_template_hash(),
-        }
-    }
-
-    #[allow(dead_code)]
-    fn into_transition(&self) -> VaultTransition {
-        match self {
-            VaultTransactionTemplate::Deposit(DepositTransactionTemplate::InitialDeposit(deposit)) =>
-                VaultTransition::Deposit(deposit.common.vault_deposit),
-            VaultTransactionTemplate::Deposit(DepositTransactionTemplate::Deposit(deposit)) =>
-                VaultTransition::Deposit(deposit.common.vault_deposit),
-            VaultTransactionTemplate::Withdrawal(withdrawal) => VaultTransition::Withdrawal(withdrawal.vault_withdrawal),
-        }
-    }
-
-    fn vault_total(&self) -> VaultAmount {
-        match self {
-            VaultTransactionTemplate::Deposit(deposit) => deposit.common().vault_total,
-            VaultTransactionTemplate::Withdrawal(withdrawal) => withdrawal.vault_total,
-        }
-    }
-}
-
-#[derive(Clone,Debug)]
-pub enum VaultTransaction {
-    Deposit(DepositTransaction),
-    Withdrawal(WithdrawalTransaction),
-}
-
-impl VaultTransaction {
-    pub fn compute_txid(&self) -> Result<Txid, VaultTransactionBuildError> {
-        match self {
-            VaultTransaction::Deposit(deposit) => deposit.compute_txid(),
-            VaultTransaction::Withdrawal(withdrawal) => Ok(withdrawal.compute_txid()),
-        }
-    }
-}
-
-impl From<DepositTransaction> for VaultTransaction {
-    fn from(deposit: DepositTransaction) -> Self { Self::Deposit(deposit) }
-}
-
-impl From<WithdrawalTransaction> for VaultTransaction {
-    fn from(withdrawal: WithdrawalTransaction) -> Self { Self::Withdrawal(withdrawal) }
-}
-
-type VaultGeneration = HashMap<VaultStateParameters, VaultTransactionTemplate>;
+pub struct Context(VaultParameters, VaultTemplateCache, AddTransactionStateCache);
+
+// FIXME: Don't love that this had to be public because VaultTemplates is in the public interface.
+// Consider wrapping this in a newtype to protect it.
+pub(crate) type VaultGeneration = HashMap<VaultStateParameters, VaultTransactionTemplate>;
 
 pub struct VaultGenerationIterator<'p, 's, C: Verification> {
     parameters: &'p VaultParameters,
@@ -1770,13 +469,6 @@ impl VaultExtendedKeyDerivationPath {
     }
 }
 
-#[derive(Debug)]
-enum HistoryToParametersError {
-    InvalidParentDepth,
-    InvalidParameters,
-    InconsistentParameters,
-}
-
 impl VaultParameters {
     pub fn new(
             scale: VaultScale,
@@ -1823,14 +515,14 @@ impl VaultParameters {
         xpub.to_pub().0
     }
 
-    fn master_key<C: Verification>(&self, secp: &Secp256k1<C>, depth: Depth) -> XOnlyPublicKey {
+    pub(crate) fn master_key<C: Verification>(&self, secp: &Secp256k1<C>, depth: Depth) -> XOnlyPublicKey {
         self.master_key_full(secp, depth).x_only_public_key().0
     }
 
     // Similar to the recovery case, if the hot key is compromised, it's actually best if they
     // initiate a withdrawal so we can recognize the hot key is compromised and initiate a
     // recovery.
-    fn hot_key<C: Verification>(&self, secp: &Secp256k1<C>, depth: Depth) -> XOnlyPublicKey {
+    pub(crate) fn hot_key<C: Verification>(&self, secp: &Secp256k1<C>, depth: Depth) -> XOnlyPublicKey {
         let path = [
             ChildNumber::from_normal_idx(depth as u32).expect("sane child number")
         ];
@@ -1839,32 +531,6 @@ impl VaultParameters {
             .expect("non-hardened derivation of a reasonable depth shouldn't fail");
 
         xpub.to_x_only_pub()
-    }
-
-    /// Script for spending an unvault output
-    fn withdrawal_script<C: Verification>(&self, secp: &Secp256k1<C>, depth: Depth, timelock: relative::LockTime) -> ScriptBuf {
-        // TODO: decide if we want to omit the CSV when timelock is 0
-        // Conservative estimating the push_int size
-        builder_with_capacity(5 + 1 + 33 + 1)
-            .push_int(timelock.to_consensus_u32() as i64)
-            .push_opcode(OP_CSV)
-            .push_opcode(OP_DROP)
-            .push_x_only_key(&self.hot_key(secp, depth))
-            .push_opcode(OP_CHECKSIG)
-            .into_script()
-    }
-
-    /// Script for spending recovering an unvault output to the cold key
-    fn recovery_script<C: Verification>(&self, secp: &Secp256k1<C>, depth: Depth, recovery_tx: &Transaction, input_index: u32) -> ScriptBuf {
-        let recovery_template = get_default_template(recovery_tx, input_index);
-
-        builder_with_capacity(33 + 1 + 1 + 33 + 1)
-            .push_slice(recovery_template.to_byte_array())
-            .push_opcode(OP_CHECKTEMPLATEVERIFY)
-            .push_opcode(OP_DROP)
-            .push_x_only_key(&self.recovery_key(secp, depth))
-            .push_opcode(OP_CHECKSIG)
-            .into_script()
     }
 
     // Spend either a withdrawn balance, the vault balance, or both, to the cold key
@@ -1900,7 +566,11 @@ impl VaultParameters {
     }
 
     fn vault_output_spend_conditions<C: Verification>(&self, secp: &Secp256k1<C>, depth: Depth, parameter: &VaultStateParameters, next_states: &VaultGeneration) -> Vec<(VaultOutputSpendCondition, SignedNextStateTemplate)> {
-        let (vault_value, withdrawal_amount) = parameter.get_result();
+        let vault_value = parameter.result_value();
+        let withdrawal_amount = match parameter.transition {
+            VaultTransition::Withdrawal(withdrawal) => withdrawal,
+            _ => VaultAmount::ZERO,
+        };
 
         if vault_value <= VaultAmount::ZERO {
             return Vec::new();
@@ -1910,8 +580,9 @@ impl VaultParameters {
         let mut transitions: Vec<_> = self
             .state_transitions_single(vault_value, depth + 1)
             .filter_map(|params| {
-                if params.parent_transition != Some(parameter.transition) {
-                    return None;
+                match (parameter.transition, params.parent_transition) {
+                    (_, None) => { return None; }
+                    (transition, Some(parent_transition)) => if transition != parent_transition { return None; }
                 }
 
                 if let Some(next_state) = next_states.get(&params) {
@@ -1930,6 +601,7 @@ impl VaultParameters {
                                     VaultOutputSpendCondition::Withdrawal(amount),
                                 VaultTransition::Deposit(amount) =>
                                     VaultOutputSpendCondition::Deposit(amount),
+                                
                             },
                             transition_script_template,
                         )
@@ -1964,6 +636,8 @@ impl VaultParameters {
                     VaultOutputSpendCondition::Recovery {
                         recovery_type: RecoveryType::VaultOnly,
                         vault_balance: vault_value,
+                        // FIXME: I think this is a bug! withdrawal_amount should reflect the
+                        // amount of the withdrawal output, even if we're ignoring it!
                         withdrawal_amount: VaultAmount::ZERO,
                     },
                     SignedNextStateTemplate {
@@ -2002,7 +676,7 @@ impl VaultParameters {
         transitions
     }
 
-    fn spend_condition_weight(&self, condition: &VaultOutputSpendCondition) -> u32 {
+    pub(crate) fn spend_condition_weight(&self, condition: &VaultOutputSpendCondition) -> u32 {
         (match condition {
             VaultOutputSpendCondition::Deposit(amount) => (self.max_deposit_per_step - *amount).to_unscaled_amount(),
             VaultOutputSpendCondition::Withdrawal(amount) => (self.max_withdrawal_per_step - *amount).to_unscaled_amount(),
@@ -2012,64 +686,41 @@ impl VaultParameters {
 
     // FIXME: I think we should just return the spend conditions as well, this is nearly duplicated
     // everywhere we build a VaultOutputSpendInfo
-    fn vault_output<C: Verification>(&self, secp: &Secp256k1<C>, depth: Depth, parameter: &VaultStateParameters, next_states: Option<&VaultGeneration>) -> TxOut {
-        let (next_value, _) = parameter.get_result();
+    fn vault_output<C: Verification>(&self, secp: &Secp256k1<C>, depth: Depth, parameters: &VaultStateParameters, next_states: Option<&VaultGeneration>) -> VaultOutputSpendInfo {
+        let next_value = parameters.result_value();
         assert!(next_value > VaultAmount::ZERO);
 
-        if let Some(next_states) = next_states {
-            let spend_conditions = self.vault_output_spend_conditions(secp, depth, parameter, next_states);
+        let conditions = if let Some(next_states) = next_states {
+            Some(
+                self.vault_output_spend_conditions(secp, depth, &parameters, next_states)
+            )
 
-            let master_key = self.master_key(secp, depth);
-            let spend_info = TaprootBuilder::with_huffman_tree(
-                    spend_conditions.iter().map(|(condition, script)| (self.spend_condition_weight(&condition), script.to_scriptbuf()))
-                )
-                .expect("taproot tree builder")
-                .finalize(secp, master_key)
-                .expect("taproot tree finalize");
-
-            TxOut {
-                value: self.scale.scale_amount(next_value),
-                script_pubkey: ScriptBuf::new_p2tr_tweaked(spend_info.output_key()),
-            }
-        // Final state, only spendable by master
         } else {
-            let master_key = self.master_key(secp, depth);
+            None
+        };
 
-            // TODO: CSFS delegated recursion
-            let script_pubkey = ScriptBuf::new_p2tr(secp, master_key, None);
-
-            TxOut {
-                value: self.scale.scale_amount(next_value),
-                script_pubkey,
-            }
-        }
+        VaultOutputSpendInfo::new(
+            secp,
+            self,
+            depth,
+            conditions,
+            next_value,
+        )
     }
 
     fn deposit_template<C: Verification>(&self, secp: &Secp256k1<C>, depth: Depth, deposit_amount: VaultAmount, parameter: &VaultStateParameters, next_states: Option<&VaultGeneration>) -> DepositTransactionTemplate {
-        let (vault_total, _withdrawal_amount) = parameter.get_result();
+        let vault_total = parameter.result_value();
 
         let vault_output = self.vault_output(secp, depth, parameter, next_states);
 
-        let common = DepositTransactionTemplateCommon {
-            depth,
-            vault_scale: self.scale,
-            vault_output,
-            vault_deposit: deposit_amount,
-            vault_total,
-        };
+        let common = vault_output.to_deposit_common(deposit_amount, vault_total, self.scale);
 
         match parameter.parent_transition {
-            None => {
-                DepositTransactionTemplate::InitialDeposit(
-                    InitialDepositTransactionTemplate { common }
-                )
-            }
+            None => common.into_initial_deposit_template(),
             Some(parent_transition) => {
-                let vault_input_lock_time = self.vault_input_lock_time(parent_transition);
+                let lock_time = self.vault_input_lock_time(parent_transition);
 
-                DepositTransactionTemplate::Deposit(
-                    TailDepositTransactionTemplate { common, vault_input_lock_time }
-                )
+                common.into_tail_deposit_template(lock_time)
             }
         }
     }
@@ -2077,31 +728,14 @@ impl VaultParameters {
     fn withdrawal_output_info<C: Verification>(&self, secp: &Secp256k1<C>, depth: Depth, withdrawal_amount: VaultAmount, vault_total: VaultAmount) -> WithdrawalOutputSpendInfo {
         let timelock = self.vault_input_lock_time(VaultTransition::Withdrawal(withdrawal_amount));
 
-        // NOTE: The templates are at `depth + 1`, but the scripts are at `depth`
-        let master_pubkey = self.master_key(secp, depth);
-        let hot_pubkey = self.hot_key(secp, depth);
-
-        let timelocked_withdrawal_script = self.withdrawal_script(secp, depth, timelock);
-
-        let single_recovery_template = self.recovery_template(secp, depth + 1, VaultAmount::ZERO, withdrawal_amount);
-        let single_recovery_script = self.recovery_script(secp, depth, &single_recovery_template, 0);
-
-        let double_recovery_script = if vault_total > VaultAmount::ZERO {
-            let double_recovery_tx = self.recovery_template(secp, depth + 1, vault_total, withdrawal_amount);
-
-            Some(self.recovery_script(secp, depth, &double_recovery_tx, 1))
-        } else {
-            None
-        };
-
-        WithdrawalOutputSpendInfo {
-            single_recovery_script,
-            double_recovery_script,
-            timelocked_withdrawal_script,
+        WithdrawalOutputSpendInfo::from_parameters(
+            secp,
+            self,
+            depth,
             timelock,
-            hot_pubkey,
-            master_pubkey,
-        }
+            vault_total,
+            withdrawal_amount,
+        )
     }
 
     /// Generate a single transaction template.
@@ -2109,7 +743,7 @@ impl VaultParameters {
     fn transaction_template<C: Verification>(&self, secp: &Secp256k1<C>, depth: Depth, parameters: &VaultStateParameters, next_states: Option<&VaultGeneration>) -> VaultTransactionTemplate {
         parameters.assert_valid();
 
-        let (vault_total, _withdrawal_amount) = parameters.get_result();
+        let vault_total = parameters.result_value();
 
         match parameters.transition {
             VaultTransition::Deposit(deposit_amount) => {
@@ -2124,7 +758,7 @@ impl VaultParameters {
 
                 let vault_input_lock_time = self.vault_input_lock_time(parent_transition);
 
-                let vault_output = if withdrawal_amount < parameters.previous_value {
+                let vault_output_spend_info = if withdrawal_amount < parameters.previous_value {
                     Some(self.vault_output(secp, depth, parameters, next_states))
                 } else {
                     None
@@ -2132,20 +766,16 @@ impl VaultParameters {
 
                 let withdrawal_output_info = self.withdrawal_output_info(secp, depth, withdrawal_amount, vault_total);
 
-                let withdrawal_output = TxOut {
-                    value: self.scale.scale_amount(withdrawal_amount),
-                    script_pubkey: withdrawal_output_info.script_pubkey(secp),
-                };
-
                 VaultTransactionTemplate::Withdrawal(
-                    WithdrawalTransactionTemplate {
-                        depth,
-                        vault_output,
-                        withdrawal_output,
-                        vault_total,
-                        vault_withdrawal: withdrawal_amount,
-                        vault_input_lock_time,
-                    }
+                    withdrawal_output_info
+                        .into_withdrawal_template(
+                            depth,
+                            vault_output_spend_info,
+                            vault_input_lock_time,
+                            vault_total,
+                            withdrawal_amount,
+                            self.scale
+                        )
                 )
             }
         }
@@ -2294,7 +924,7 @@ impl VaultParameters {
         }
     }
 
-    fn tx_templates<C: Verification>(&self, secp: &Secp256k1<C>, depth: Depth, next_states: Option<&VaultGeneration>) -> VaultGeneration {
+    pub(crate) fn tx_templates<C: Verification>(&self, secp: &Secp256k1<C>, depth: Depth, next_states: Option<&VaultGeneration>) -> VaultGeneration {
         self.state_transitions(depth)
             .into_par_iter()
             .map(|parameter| (
@@ -2334,11 +964,12 @@ impl VaultParameters {
     }
 }
 
-#[derive(Clone, Debug)]
-enum VaultHistoryTransactionDetails {
+#[derive(Clone, Debug, Eq, PartialEq)]
+#[allow(dead_code)]
+pub(crate) enum VaultHistoryTransactionDetails {
     VaultDeposit {
         deposit_amount: VaultAmount,
-        vout: u32,
+        vault_vout: u32,
     },
     VaultWithdrawal {
         withdrawal_amount: VaultAmount,
@@ -2361,30 +992,6 @@ enum VaultHistoryTransactionDetails {
     },
 }
 
-impl VaultHistoryTransactionDetails {
-    fn try_into_transition(&self) -> Option<VaultTransition> {
-        match self {
-            VaultHistoryTransactionDetails::VaultDeposit { deposit_amount, .. } =>
-                Some(VaultTransition::Deposit(*deposit_amount)),
-            VaultHistoryTransactionDetails::VaultWithdrawal { withdrawal_amount, .. } =>
-                Some(VaultTransition::Withdrawal(*withdrawal_amount)),
-            _ => None,
-        }
-    }
-
-    fn from_transition(transition: VaultTransition, vault_result_value: VaultAmount) -> Self {
-        match transition {
-            VaultTransition::Deposit(deposit_amount) => DepositOutputInfo {
-                deposit_amount,
-            }.to_vault_history_transaction_details(),
-            VaultTransition::Withdrawal(withdrawal_amount) => WithdrawalOutputInfo {
-                vault_result_value,
-                withdrawal_amount,
-            }.to_vault_history_transaction_details()
-        }
-    }
-}
-
 #[derive(Clone,Copy,Debug)]
 /// Indicates what kind of vault transaction was found that cannot be
 /// represented as a [`VaultTransition`].
@@ -2393,72 +1000,36 @@ pub enum InvalidTransitionError {
     Recovery,
 }
 
-#[derive(Clone,Debug)]
+#[derive(Clone, Debug, Eq, PartialEq)]
 pub struct VaultHistoryTransaction {
     txid: Txid,
     #[allow(dead_code)]
     depth: Depth,
-    transition: VaultHistoryTransactionDetails,
+    details: VaultHistoryTransactionDetails,
     result_value: VaultAmount,
 }
 
 impl VaultHistoryTransaction {
+    #[allow(dead_code)]
+    pub(crate) fn new(txid: Txid, depth: Depth, details: VaultHistoryTransactionDetails, result_value: VaultAmount) -> Self {
+        VaultHistoryTransaction {
+            txid,
+            depth,
+            details,
+            result_value,
+        }
+    }
+
     /// Get the vault outpoint if it exists
     pub fn vault_outpoint(&self) -> Option<OutPoint> {
-        match self.transition {
-            VaultHistoryTransactionDetails::VaultDeposit { vout, .. } =>
+        match self.details {
+            VaultHistoryTransactionDetails::VaultDeposit { vault_vout: vout, .. } =>
                 Some(OutPoint {txid: self.txid, vout}),
             VaultHistoryTransactionDetails::VaultWithdrawal { vault_vout: vout, .. } =>
                 vout.map(|vout| OutPoint{ txid: self.txid, vout}),
             _ => None,
         }
     }
-
-    pub fn into_parameters(&self,
-        parent_transition: Option<VaultTransition>,
-        max: Option<VaultAmount>
-    ) -> Option<VaultStateParameters> {
-        let transition = self.transition
-            .try_into_transition()?;
-
-        self.result_value
-            .apply_transition(
-                transition.invert(),
-                max,
-            )
-            .map(|previous_value| {
-                VaultStateParameters {
-                    transition,
-                    previous_value,
-                    parent_transition,
-                }
-            })
-    }
-
-    /// Create parameters representing the child transaction with the given transition
-    /// Does not validate the resulting parameters against the Vault's constraints
-    pub fn to_child_parameters(&self, transition: VaultTransition) -> Result<VaultStateParameters, InvalidTransitionError> {
-        let parent_transition = match self.transition {
-            VaultHistoryTransactionDetails::VaultDeposit { deposit_amount, .. } => VaultTransition::Deposit(deposit_amount),
-            VaultHistoryTransactionDetails::VaultWithdrawal { withdrawal_amount, .. } => VaultTransition::Withdrawal(withdrawal_amount),
-            VaultHistoryTransactionDetails::KeySpend {  } => { return Err(InvalidTransitionError::KeySpend) }
-            VaultHistoryTransactionDetails::Recovery { .. } => { return Err(InvalidTransitionError::Recovery) }
-        };
-
-        Ok(
-            VaultStateParameters {
-                transition,
-                previous_value: self.result_value,
-                parent_transition: Some(parent_transition),
-            }
-        )
-    }
-}
-
-#[derive(Debug)]
-pub enum VaultInitializationError {
-    MigrationError(MigrationError),
-    ConfigurationError(rusqlite::Error),
 }
 
 #[derive(Clone,Copy,Debug)]
@@ -2488,6 +1059,10 @@ pub enum RecoveryCreationError {
     MaxDepth,
     HistoryError,
     UnrecoverableLastTransaction,
+    // Generalization of VaultUnopened, VaultClosed, and UnrecoverableLastTransaction
+    // Might eliminate those variants, I don't think we care about the reason that much, plus it's
+    // harder to distinguish in the new model
+    NoOutputs,
 }
 
 /// A local identifier for a vault
@@ -2515,43 +1090,6 @@ impl AccountId {
     pub fn to_cold_derivation_path(&self) -> DerivationPath {
         VaultExtendedKeyDerivationPath::ColdKey(self.0)
             .to_derivation_path()
-    }
-}
-
-pub struct SqliteVaultStorage {
-    sqlite: rusqlite::Connection,
-}
-
-#[derive(Debug)]
-pub enum SqliteInitializationError {
-    MigrationError(MigrationError),
-    ConnectionConfigurationError(rusqlite::Error),
-}
-
-impl SqliteVaultStorage {
-    pub fn from_connection(mut sqlite: rusqlite::Connection) -> Result<Self, SqliteInitializationError> {
-        migrate(&mut sqlite)
-            .map_err(|e| SqliteInitializationError::MigrationError(e))?;
-        configure(&sqlite)
-            .map_err(|e| SqliteInitializationError::ConnectionConfigurationError(e))?;
-
-        Ok(SqliteVaultStorage {
-            sqlite,
-        })
-    }
-}
-
-impl Deref for SqliteVaultStorage {
-    type Target = rusqlite::Connection;
-
-    fn deref(&self) -> &Self::Target {
-        &self.sqlite
-    }
-}
-
-impl DerefMut for SqliteVaultStorage {
-    fn deref_mut(&mut self) -> &mut Self::Target {
-        &mut self.sqlite
     }
 }
 
@@ -2589,515 +1127,1023 @@ impl SubmitPackage for Client {
     }
 }
 
-#[derive(Clone,Hash,Eq,PartialEq)]
-struct SignedNextStateTemplate {
-    pubkey: XOnlyPublicKey,
-    next_state_template_hash: sha256::Hash,
-}
-
-impl SignedNextStateTemplate {
-    fn to_scriptbuf(&self) -> ScriptBuf {
-        // We enforce sequence indirectly via CTV
-        builder_with_capacity(33 + 1 + 1 + 33 + 1)
-            .push_slice(self.next_state_template_hash.to_byte_array())
-            .push_opcode(OP_CHECKTEMPLATEVERIFY)
-            .push_opcode(OP_DROP)
-            .push_x_only_key(&self.pubkey)
-            .push_opcode(OP_CHECKSIG)
-            .into_script()
-    }
-}
-
-impl PartialEq<Script> for SignedNextStateTemplate {
-    fn eq(&self, other: &Script) -> bool {
-        self.to_scriptbuf().as_script() == other
-    }
-}
-
-#[derive(Clone,Copy,Debug,Hash,Eq,PartialEq)]
-enum RecoveryType {
-    VaultOnly,
-    VaultWithWithdrawal,
-}
-
-#[derive(Clone,Copy,Debug,Hash,Eq,PartialEq)]
-enum VaultOutputSpendCondition {
-    Deposit(VaultAmount),
-    Withdrawal(VaultAmount),
-    // FIXME: Seems like recovery_type should just be RecoveryDetails with a variant for vault
-    // only, withdrawal only, and both?
-    Recovery {
-        recovery_type: RecoveryType,
-        vault_balance: VaultAmount,
-        withdrawal_amount: VaultAmount,
-    },
-}
-
-#[derive(Clone,Debug)]
-struct VaultOutputSigningInfo {
-    pubkey: XOnlyPublicKey,
-    control_block: ControlBlock,
-    vault_prevout: TxOut,
-    //depth: Depth,
-    script: ScriptBuf,
-}
-
-type WithdrawalOutputSigningInfo = VaultOutputSigningInfo;
-
-impl VaultOutputSigningInfo {
-    fn sign<C: Signing, T: Borrow<TxOut>>(&self, secp: &Secp256k1<C>, keypair: &Keypair, transaction: &Transaction, input_index: usize, prevouts: &Prevouts<T>) -> Result<taproot::Signature, sighash::TaprootError> {
-        let tap_leaf_hash = TapLeafHash::from_script(self.script.as_ref(), LeafVersion::TapScript);
-        let sighash = SighashCache::new(transaction)
-            .taproot_signature_hash(input_index, prevouts, None, Some((tap_leaf_hash, 0xFFFFFFFF)), TapSighashType::Default)?;
-
-        // FIXME: seems like there should be shortcuts for a couple of these things?
-        let message: Message = sighash.into();
-        let signature = secp.sign_schnorr(&message, keypair);
-
-        Ok(taproot::Signature {
-            signature,
-            sighash_type: TapSighashType::Default,
-        })
-    }
-
-    pub fn build_witness(&self, signature: taproot::Signature) -> Witness {
-        let mut witness = Witness::new();
-        witness.push(signature.to_vec());
-        witness.push(&self.script);
-        witness.push(self.control_block.serialize());
-
-        witness
-    }
-}
-
-pub struct VaultOutputSpendInfo {
-    spend_info: TaprootSpendInfo,
-    output: TxOut,
-    depth: Depth,
-    branches: HashMap<VaultOutputSpendCondition, SignedNextStateTemplate>,
-}
-
-#[derive(Clone,Debug)]
-pub enum DepositSignError {
-    NoSignatureNeeded,
-    SighashError(sighash::TaprootError),
-    NoShapeTransaction,
-}
-
-#[derive(Clone,Debug)]
-pub enum WithdrawalSignError {
-    SighashError(sighash::TaprootError),
-}
-
-#[derive(Debug)]
-pub enum KeypairDerivationError {
-    WrongKey,
-    DerivationDepthExceeded,
-    NoSigningInfo,
-}
-
-pub struct Vault {
-    #[allow(dead_code)]
-    id: VaultId,
-    parameters: VaultParameters,
-    history: Vec<(VaultHistoryTransaction, Option<(u32, BlockHash)>)>,
-}
-
-#[derive(Debug)]
-pub enum CreateVaultError {
-    SqliteError(rusqlite::Error),
-}
-
-#[derive(Debug)]
-enum ConnectForeignTransactionError {
-    InvalidWitness,
-}
-
-impl Vault {
-    pub fn create_new(storage: &mut SqliteVaultStorage, name: &str, parameters: VaultParameters) -> Result<Self, CreateVaultError> {
-        let mut statement = storage.prepare(r#"
-            insert into
-                mccv_vault
-            (
-                name
-            )
-            values (?)
-            returning id
-        "#)
-        .map_err(|e| CreateVaultError::SqliteError(e))?;
-
-        let vault_ids: Vec<i64> = statement
-            .query_map(
-                params![name],
-                |row| row.get(0),
-            )
-            .map_err(|e| CreateVaultError::SqliteError(e))?
-            .collect::<rusqlite::Result<Vec<i64>>>()
-            .map_err(|e| CreateVaultError::SqliteError(e))?;
-
-        Ok(Self {
-            id: vault_ids[0],
-            parameters,
-            history: Vec::new(),
-        })
-    }
-
-    #[allow(unused)]
-    pub fn load(id: VaultId, storage: &mut SqliteVaultStorage) -> Result<Self, rusqlite::Error> {
-        let _vault_id = storage.query_row("select (id) from mccv_vault", params![id], |row: &Row| -> rusqlite::Result<i64> { row.get(0) })?;
-
-        Ok(Self {
-            id,
-            parameters: todo!(),
-            history: todo!(),
-        })
-    }
-
-    pub fn list(connection: &mut Connection) -> Result<Vec<(VaultId, String)>, rusqlite::Error> {
-        let mut query = connection.prepare(r#"
-            select
-            (
-                id,
-                name
-            )
-            from
-                mccv_vault
-        "#)?;
-
-        let result = query.query_map(params![], |row| {
-            let id: VaultId = row.get(0)?;
-            let name: String = row.get(1)?;
-            Ok((id, name))
-        })?
-        .collect::<rusqlite::Result<Vec<(VaultId, String)>>>();
-        result
-    }
-
-    pub fn store(&self, _connection: &mut Connection) -> Result<Self, rusqlite::Error> {
-        todo!()
-    }
-
-    fn get_current_depth(&self) -> Depth {
-        self.history.len() as Depth
-    }
-
-    /// Return the confirmed balance of the vault by a given height, or any height
-    pub fn confirmed_balance(&self, height: Option<u32>) -> Amount {
-        self.history.iter().rev()
-            .skip_while(|(_tx, confirmation)| {
-                if let Some((confirmation_height, _)) = confirmation {
-                    // If we have a max height and it's greater than the confirmation height of
-                    // this transaction, skip it.
-                    height
-                        .map(|height| height < *confirmation_height)
-                        .unwrap_or(false)
-                } else {
-                    false
-                }
-            })
-            .next()
-            .map(|(tx, _confirmation)|
-                 self.parameters.scale.scale_amount(tx.result_value)
-             )
-            .unwrap_or(Amount::ZERO)
-    }
-
-    // Had to make static to satisfy borrow checker
-    // TODO: Handle key spend (master key)
-    #[allow(dead_code)]
-    fn try_connect_foreign_tx<C: Verification>(secp: &Secp256k1<C>, parameters: &VaultParameters, grandparent_transition: Option<VaultTransition>, previous_tx: &VaultHistoryTransaction, transaction: &Transaction, input_index: u32) -> Result<VaultHistoryTransaction, ConnectForeignTransactionError> {
-        let depth = previous_tx.depth + 1;
-
-        let template_hash = get_default_template(&transaction, input_index);
-
-        let templates = parameters.templates_at_depth(secp, depth);
-
-        let transitions: Vec<(VaultStateParameters, VaultTransactionTemplate)> =
-            templates
-            .iter()
-            .filter_map(|(state, vtt)| {
-                if vtt.vault_template_hash() == template_hash {
-                    Some((state.clone(), vtt.clone()))
-                } else {
-                    None
-                }
-            })
-            .collect();
-
-        if transitions.is_empty() {
-            let previous_state = previous_tx.into_parameters(grandparent_transition, Some(parameters.max))
-                // FIXME
-                .expect("valid state");
-
-            let previous_transitions: Vec<_> = parameters
-                .templates_at_depth(secp, previous_tx.depth)
+// FIXME: does it actually just make sense for (C, T) to be T?
+pub(crate) fn spend_condition_lookup<'a, Ss, C, Cs, T>(scripts: Ss, conditions: Cs) -> HashMap<TaprootMerkleBranch, (C, T)>
+where
+    Ss: IntoIterator<Item = ((&'a Script, LeafVersion), &'a BTreeSet<TaprootMerkleBranch>)>,
+    Cs: Fn(&Script) -> Option<(C, T)>,
+    T: Clone,
+    C: Clone,
+{
+    scripts.into_iter()
+        .flat_map(|((script, _leaf_version), merkle_branches)| {
+            conditions(script)
                 .into_iter()
-                .filter_map(|(state, transaction)| {
-                    if previous_state != state {
-                        return None;
+                .flat_map(|(condition, template)| {
+                    merkle_branches
+                        .iter()
+                        .map(move |branch|
+                            (
+                                branch.clone(),
+                                (
+                                    condition.clone(),
+                                    template.clone(),
+                                ),
+                            )
+                        )
                     }
+                )
+        })
+        .collect()
+}
 
-                    // FIXME: check depth
-                    let matching_conditions: Vec<_> = parameters.vault_output_spend_conditions(secp, previous_tx.depth, &state, &templates)
-                        .into_iter()
-                        .filter(|(_condition, script)| {
-                            script.next_state_template_hash == template_hash
-                        })
-                        .collect();
+pub(crate) fn massage_script_map<'a>(arg: (&'a (ScriptBuf, LeafVersion), &'a BTreeSet<TaprootMerkleBranch>)) -> ((&'a Script, LeafVersion), &'a BTreeSet<TaprootMerkleBranch>) {
+    ((arg.0.0.as_script(), arg.0.1), arg.1)
+}
 
-                    debug_assert!(matching_conditions.len() <= 1);
+#[derive(Clone, Copy, Debug, Eq, Hash, PartialEq, Ord, PartialOrd)]
+pub(crate) enum RecoveryInput {
+    None,
+    Ignored(VaultAmount),
+    Spent(VaultAmount),
+}
 
-                    // XXX: IDK What's idiomatic here, .first().map() would be more concise but I feel like
-                    // this expresses intent better
-                    if let Some((condition, _script)) = matching_conditions.first() {
-                        Some((state, *condition, transaction))
+impl RecoveryInput  {
+    fn from_amount(amount: VaultAmount, spent: bool) -> Self {
+        if amount == VaultAmount::ZERO {
+            Self::None
+        } else if spent {
+            Self::Spent(amount)
+        } else {
+            Self::Ignored(amount)
+        }
+    }
+}
+
+#[derive(Clone, Debug, Eq, Hash, PartialEq, Ord, PartialOrd)]
+pub(crate) enum VaultTransactionMetadata {
+    InitialDeposit(VaultAmount),
+    Deposit {
+        previous_value: VaultAmount,
+        deposit: VaultAmount,
+    },
+    Withdrawal {
+        previous_value: VaultAmount,
+        withdrawal: VaultAmount,
+    },
+    WithdrawalSpend {
+        withdrawal_vins: BTreeSet<u32>,
+    },
+    Recovery {
+        vault_output_value: RecoveryInput,
+        withdrawal_output_value: RecoveryInput,
+    },
+    KeySpend,
+}
+
+#[derive(Clone, Debug, Eq, Hash, PartialEq, Ord, PartialOrd)]
+pub struct VaultStateTransaction {
+    txid: Txid,
+    transaction: Transaction,
+    // Depth of vault transaction from initial deposit
+    depth: Depth,
+    metadata: VaultTransactionMetadata,
+    /// Key: parent txid
+    parents: BTreeMap<Txid, Rc<VaultStateTransaction>>,
+}
+
+impl ContractTransaction for VaultStateTransaction {
+    fn txid(&self) -> Txid { self.txid }
+}
+
+impl VaultStateTransaction {
+    fn input_utxos(&self) -> impl Iterator<Item = (u32, VaultStateUtxo)> {
+        match &self.metadata {
+            VaultTransactionMetadata::InitialDeposit(_) => {
+                assert!(self.parents.is_empty(), "Initial deposit has no tracked parents");
+
+                Either::A(iter::empty())
+            }
+            VaultTransactionMetadata::Deposit { .. } => {
+                let (_parent_txid, parent) = self.parents.iter().next().expect("Deposit must have parent");
+
+                Either::B(Either::A(iter::once((0, VaultStateUtxo(parent.clone(), VaultStateOutput::Vault)))))
+            }
+            VaultTransactionMetadata::Withdrawal { .. } => {
+                let (_parent_txid, parent) = self.parents.iter().next().expect("Deposit must have parent");
+
+                Either::B(Either::B(Either::A(iter::once((0, VaultStateUtxo(parent.clone(), VaultStateOutput::Vault))))))
+            }
+            VaultTransactionMetadata::KeySpend => todo!("keyspend"),
+            VaultTransactionMetadata::Recovery{ vault_output_value, withdrawal_output_value } => {
+                let (_parent_txid, parent) = self.parents.iter().next().expect("Recovery must have parent");
+
+                Either::B(Either::B(Either::B(Either::A(
+                    iter::empty()
+                        .chain(
+                            match vault_output_value {
+                                RecoveryInput::Spent(_) => Some(
+                                    VaultStateUtxo(parent.clone(), VaultStateOutput::Vault)        
+                                ),
+                                _ => None
+                            }
+                        )
+                        .chain(
+                            match withdrawal_output_value {
+                                RecoveryInput::Spent(_) => Some(
+                                    VaultStateUtxo(parent.clone(), VaultStateOutput::Vault)        
+                                ),
+                                _ => None
+                            }
+                        )
+                        .enumerate()
+                        .map(|(input_index, utxo)| (input_index as u32, utxo))
+                ))))
+            },
+            VaultTransactionMetadata::WithdrawalSpend { withdrawal_vins } => {
+                let inputs: Vec<_> = withdrawal_vins
+                    .into_iter()
+                    .map(|vin| {
+                        let input = &self.transaction.input[*vin as usize];
+
+                        let parent = &self.parents[&input.previous_output.txid];
+
+                        (*vin, VaultStateUtxo(parent.clone(), VaultStateOutput::Withdrawal))
+                    })
+                    .collect();
+
+                Either::B(Either::B(Either::B(Either::B(
+                    inputs.into_iter()
+                ))))
+            }
+        }
+    }
+
+    #[allow(dead_code)]
+    fn output_type(&self, vout: u32) -> Option<VaultStateOutput> {
+        match (&self.metadata, vout) {
+            (VaultTransactionMetadata::InitialDeposit(_), 0) |
+            (VaultTransactionMetadata::Deposit { .. },    0) =>
+                Some(VaultStateOutput::Vault),
+            (VaultTransactionMetadata::Withdrawal { previous_value, withdrawal }, vout) => {
+                if previous_value > withdrawal {
+                    if vout == 0 {
+                        Some(VaultStateOutput::Vault)
+                    } else if vout == 1 {
+                        Some(VaultStateOutput::Withdrawal)
                     } else {
                         None
                     }
-                })
-                .collect();
-
-            /*
-            for (state, condition, transaction) in previous_transitions.iter() {
-                dbg!(state, condition, transaction);
-            }
-            */
-
-            debug_assert!(previous_transitions.len() <= 1, "previous_transitions.len() = {}", previous_transitions.len());
-
-            let txid = transaction.compute_txid();
-            // FIXME: yet another place where vout information is encoded
-            if let Some((_state, condition, transaction)) = previous_transitions.first() {
-                return match condition {
-                    VaultOutputSpendCondition::Deposit(deposit_amount) => {
-                        let output_info = DepositOutputInfo {
-                            deposit_amount: *deposit_amount,
-                        };
-
-                        Ok(
-                            VaultHistoryTransaction {
-                                txid,
-                                depth,
-                                transition: output_info.to_vault_history_transaction_details(),
-                                result_value: transaction.vault_total(),
-                            }
-                        )
-                    }
-                    VaultOutputSpendCondition::Withdrawal(withdrawal_amount) => {
-                        let withdrawal_info = WithdrawalOutputInfo {
-                            vault_result_value: previous_tx.result_value,
-                            withdrawal_amount: *withdrawal_amount,
-                        };
-
-                        Ok(
-                            VaultHistoryTransaction {
-                                txid,
-                                depth,
-                                transition: withdrawal_info.to_vault_history_transaction_details(),
-                                result_value: transaction.vault_total(),
-                            }
-                        )
-                    }
-                    VaultOutputSpendCondition::Recovery { recovery_type, .. } => {
-                        // FIXME: We don't(can't?) handle split recovery here
-                        // Actually we might be able to special case where the parent tx is a also
-                        // a recovery (or if there's a recovery in the history already?)
-                        // We just add this as a second history tx?
-                        // Do we even need to do this? We don't handle withdrawal-only recovery
-                        let transition = match recovery_type {
-                            RecoveryType::VaultOnly =>
-                                VaultHistoryTransactionDetails::Recovery { withdrawal_txid: None, vault_txid: Some(previous_tx.txid) },
-                            RecoveryType::VaultWithWithdrawal =>
-                                VaultHistoryTransactionDetails::Recovery { withdrawal_txid: Some(previous_tx.txid), vault_txid: Some(previous_tx.txid) },
-                        };
-
-                        Ok(
-                            VaultHistoryTransaction {
-                                txid,
-                                depth,
-                                transition,
-                                result_value: VaultAmount::ZERO,
-                            }
-                        )
-                    }
-                };
-            }
-
-            let input = &transaction.input[input_index as usize];
-            if input.witness.len() > 2 {
-                return Err(ConnectForeignTransactionError::InvalidWitness);
-            } else if input.witness.len() > 1 {
-                if input.witness[1][0] != 0x50 {
-                    return Err(ConnectForeignTransactionError::InvalidWitness);
-                }
-            }
-
-            // Empty witness
-            if input.witness.len() < 1 {
-                return Err(ConnectForeignTransactionError::InvalidWitness);
-            }
-
-            if input.witness[0].len() != 64 && input.witness[0].len() != 65 {
-                return Err(ConnectForeignTransactionError::InvalidWitness);
-            }
-
-            Ok(
-                VaultHistoryTransaction {
-                    txid: transaction.compute_txid(),
-                    depth,
-                    transition: VaultHistoryTransactionDetails::KeySpend { },
-                    result_value: VaultAmount::ZERO,
-                }
-            )
-        } else {
-            let (state, _vault_transaction_template) = transitions
-                .into_iter()
-                .filter(|(state, _vtt)| state.previous_value == previous_tx.result_value)
-                .next()
-                .expect("there must be a matching transition");
-
-            let result_value = state.previous_value
-                .apply_transition(state.transition, Some(parameters.max))
-                //FIXME: undesirable panic potential
-                .expect("transition should be valid already");
-
-            Ok(
-                VaultHistoryTransaction {
-                    txid: transaction.compute_txid(),
-                    depth,
-                    transition:
-                        VaultHistoryTransactionDetails::from_transition(
-                            state.transition,
-                            result_value,
-                        ),
-                    result_value,
-                }
-            )
-        }
-    }
-
-    #[cfg(feature = "bitcoind")]
-    pub fn apply_block<C: Verification>(&mut self, secp: &Secp256k1<C>, block: &Block, block_height: u32) -> usize {
-        let mut block_txes = block.txdata.iter();
-
-        let mut grandparent_tx: Option<&VaultHistoryTransaction> = None;
-        let mut previous_tx: Option<&VaultHistoryTransaction> = None;
-        let mut iter = self.history.iter_mut();
-        while let Some((ref mut history_tx, ref mut confirmation)) = iter.next() {
-            if confirmation.map(|(tx_height, _block)| tx_height >= block_height).unwrap_or(true) {
-                if confirmation.is_some() {
-                    //eprintln!("reorg at height {block_height}!");
-                }
-
-                // clear the previously seen block inclusion
-                *confirmation = None;
-
-                while confirmation.is_none() {
-                    if let Some(block_tx) = block_txes.next() {
-                        if block_tx.compute_txid() == history_tx.txid {
-                            //eprintln!("found tx {}", history_tx.txid);
-                            *confirmation = Some((block_height, block.block_hash()));
-                            continue;
-                        } else if let Some(previous_tx) = previous_tx {
-                            // FIXME: We need some somewhat complicated logic to handle keyspends
-                            // and recoveries of the withdrawal tx, since it's no longer a single
-                            // UTXO, we have to account for the withdrawal output, too
-                            // Maybe we have a special field for withdrawal history?
-                            // I think that makes the most sense
-                            let grandparent_transition = grandparent_tx.and_then(|tx| tx.transition.try_into_transition());
-
-                            if let Some(history_outpoint) = previous_tx.vault_outpoint() {
-                                for (input_index, txin) in block_tx.input.iter().enumerate() {
-                                    if txin.previous_output == history_outpoint {
-                                        *history_tx = Self::try_connect_foreign_tx(secp, &self.parameters, grandparent_transition, previous_tx, block_tx, input_index as u32)
-                                            // FIXME: a key spend will cause a panic!
-                                            .expect("tx can only be spent by a valid transition tx");
-                                        *confirmation = Some((block_height, block.block_hash()));
-                                    }
-                                }
-                            } else {
-                                // If we're here we have (unconfirmed) history after the final
-                                // vault transaction and something is very wrong
-                                unreachable!("final vault transactions can't have child transactions");
-                            }
-                        }
-                    } else {
-                        break;
-                    }
-                }
-            }
-
-            grandparent_tx = previous_tx;
-            previous_tx = Some(history_tx);
-        }
-
-        // If there's more transactions left, look for other transactions
-        while let Some(block_tx) = block_txes.next() {
-            // This awkward code ensures we're not holding a reference to self.history
-            // (via previous_tx) when we go to append the history item
-            let history_item = if let Some((previous_tx, _)) = self.history.last() {
-                if let Some(history_outpoint) = previous_tx.vault_outpoint() {
-                    // FIXME: will not properly handle a transaction that keyspends both the
-                    // withdrawal and vault outputs in the same transaction, but we don't handle
-                    // keyspends at all right now.
-                    let mut input_iter = block_tx.input.iter().enumerate();
-                    loop {
-                        if let Some((input_index, txin)) = input_iter.next() {
-                            if txin.previous_output == history_outpoint {
-                                // FIXME: hideous, also assumes that history is sorted by depth,
-                                // and I kinda want to get rid of the depth field, too.
-                                let grandparent_transition = previous_tx.depth.checked_sub(1)
-                                    .and_then(|depth| self.history.get(depth as usize))
-                                    .and_then(|(tx, _)| tx.transition.try_into_transition());
-
-                                //eprintln!("foreign transaction {}", block_tx.compute_txid());
-                                let history_tx = Self::try_connect_foreign_tx(secp, &self.parameters, grandparent_transition, &previous_tx, block_tx, input_index as u32)
-                                    // FIXME: a key spend will cause a panic!
-                                    .expect("tx can only be spent by a valid transition tx");
-
-                                break Some(
-                                    (
-                                        history_tx,
-                                        Some((block_height, block.block_hash())),
-                                    )
-                                );
-                            }
-                        } else {
-                            break None;
-                        }
-                    }
+                } else if vout == 0 {
+                    Some(VaultStateOutput::Vault)
                 } else {
                     None
                 }
-            } else {
-                None
+            }
+            _ => None,
+        }
+    }
+
+    fn outputs(&self) -> impl Iterator<Item=VaultStateOutput> {
+        match &self.metadata {
+            VaultTransactionMetadata::InitialDeposit(_) |
+            VaultTransactionMetadata::Deposit { .. } =>
+                iter::empty()
+                    .chain(Some(VaultStateOutput::Vault))
+                    .chain(None),
+            VaultTransactionMetadata::Withdrawal { previous_value, withdrawal } =>
+                iter::empty()
+                    .chain(
+                        if previous_value > withdrawal {
+                            Some(VaultStateOutput::Vault)
+                        } else {
+                            None
+                        }
+                    )
+                    .chain(Some(VaultStateOutput::Withdrawal)),
+            _ => iter::empty().chain(None).chain(None),
+        }
+    }
+
+    fn output_index(&self, output: VaultStateOutput) -> Option<u32> {
+        match (&self.metadata, output) {
+            (VaultTransactionMetadata::InitialDeposit(_), VaultStateOutput::Vault) |
+            (VaultTransactionMetadata::Deposit{ .. }, VaultStateOutput::Vault) =>
+                Some(0),
+            (VaultTransactionMetadata::Withdrawal { previous_value, withdrawal }, VaultStateOutput::Vault) =>
+                if previous_value > withdrawal {
+                    Some(0)
+                } else {
+                    None
+                },
+            (VaultTransactionMetadata::Withdrawal { previous_value, withdrawal }, VaultStateOutput::Withdrawal) =>
+                if previous_value > withdrawal {
+                    Some(1)
+                } else {
+                    Some(0)
+                },
+            _ => None,
+        }
+    }
+
+    fn outpoint(&self, output: VaultStateOutput) -> Option<OutPoint> {
+        self.output_index(output)
+            .map(|index| OutPoint {
+                txid: self.transaction.compute_txid(),
+                vout: index,
+            })
+    }
+
+    fn txout(&self, output: VaultStateOutput) -> Option<&TxOut> {
+        self.output_index(output)
+            .map(|index| &self.transaction.output[index as usize])
+    }
+
+    fn vault_input(&self) -> Option<&TxIn> {
+        match &self.metadata {
+            VaultTransactionMetadata::InitialDeposit(_) => None,
+            VaultTransactionMetadata::Deposit { .. } => Some(&self.transaction.input[0]),
+            VaultTransactionMetadata::Withdrawal { .. } => Some(&self.transaction.input[0]),
+            VaultTransactionMetadata::WithdrawalSpend { .. } => None,
+            // The only two call sites for vault_input are in Deposit and Withdrawal so this is ok
+            // for now
+            // TODO: Implement though
+            VaultTransactionMetadata::Recovery { .. } => todo!("not really a case we care about either, but it probably would be good to retain this info"),
+            VaultTransactionMetadata::KeySpend => todo!("not really a case we care about, but it probably would be good to retain this info"),
+        }
+    }
+
+    fn vault_input_prevout(&self) -> Option<(u32, Rc<VaultStateTransaction>)> {
+        let prevout = &self.vault_input()?.previous_output;
+        let parent = self.parents.get(&prevout.txid)
+            // We don't *have to* panic here, but I think this is a good invariant to assert...
+            .expect("vault state transaction must have valid parents");
+
+        Some((prevout.vout, parent.clone()))
+    }
+
+    fn vault_transition(&self) -> Option<VaultTransition> {
+        match self.metadata.clone() {
+            VaultTransactionMetadata::InitialDeposit(deposit) => Some(VaultTransition::Deposit(deposit)),
+            VaultTransactionMetadata::Deposit { deposit, .. } => Some(VaultTransition::Deposit(deposit)),
+            VaultTransactionMetadata::Withdrawal { withdrawal, .. } => Some(VaultTransition::Withdrawal(withdrawal)),
+            _ => None,
+        }
+    }
+
+    fn result_value(&self) -> Option<VaultAmount> {
+        match self.metadata.clone() {
+            VaultTransactionMetadata::InitialDeposit(deposit) => Some(deposit),
+            VaultTransactionMetadata::Deposit { previous_value, deposit } => Some(previous_value + deposit),
+            VaultTransactionMetadata::Withdrawal { previous_value, withdrawal } => Some(previous_value - withdrawal),
+            _ => None,
+        }
+    }
+
+    fn withdrawal_amount(&self) -> VaultAmount {
+        match self.metadata.clone() {
+            VaultTransactionMetadata::Withdrawal { withdrawal, .. } => withdrawal,
+            _ => VaultAmount::ZERO
+        }
+    }
+
+    fn vault_state_parameters(&self) -> Option<VaultStateParameters> {
+        match self.metadata.clone() {
+            VaultTransactionMetadata::InitialDeposit(deposit) => Some(
+                VaultStateParameters {
+                    transition: VaultTransition::Deposit(deposit),
+                    previous_value: VaultAmount::ZERO,
+                    parent_transition: None,
+                }
+            ),
+            VaultTransactionMetadata::Deposit { deposit, previous_value } => Some(
+                self.vault_input_prevout()
+                    .and_then(|(_vout, parent)| parent.vault_transition())
+                    .map(|parent_transition|
+                        VaultStateParameters {
+                            transition:
+                                VaultTransition::Deposit(deposit),
+                            previous_value,
+                            parent_transition:
+                                Some(parent_transition),
+                        }
+                    )
+                    // XXX: I think I'd rather panic here if we have some invalid state, but I'm
+                    // kinda on the fence right now...
+                    .expect("vault deposit output has valid transition")
+            ),
+            VaultTransactionMetadata::Withdrawal { previous_value, withdrawal } => Some(
+                self.vault_input_prevout()
+                    .and_then(|(_vout, parent)| parent.vault_transition())
+                    .map(|parent_transition|
+                         VaultStateParameters {
+                            transition:
+                                VaultTransition::Withdrawal(withdrawal),
+                            previous_value,
+                            parent_transition:
+                                Some(parent_transition),
+                        }
+                    )
+                    // XXX: I think I'd rather panic here if we have some invalid state, but I'm
+                    // kinda on the fence right now...
+                    .expect("vault deposit output has valid transition")
+            ),
+            _ => None
+        }
+    }
+}
+
+#[derive(Debug)]
+#[cfg(feature = "bitcoind")]
+pub enum ApplyBlockError {
+    AddBlockError(AddBlockError),
+    AddTransactionError(AddTransactionError<ConnectVaultTransactionError>),
+    InternalError,
+}
+
+// Kind of annoying how much must be copied. the Control block can be up to 4KiB + 33B
+#[allow(dead_code)]
+enum TaprootWitness<'a> {
+    Keyspend {
+        signature: taproot::Signature,
+        annex: Option<&'a [u8]>,
+    },
+    ScriptSpend {
+        script: &'a Script,
+        control_block: ControlBlock,
+        annex: Option<&'a [u8]>,
+    },
+}
+
+#[derive(Debug)]
+enum TaprootWitnessError {
+    InvalidSignature,
+    EmptyWitness,
+    #[allow(dead_code)]
+    InvalidControlBlock(bitcoin::taproot::TaprootError),
+    InvalidWitness,
+}
+
+impl<'a> TryFrom<&'a Witness> for TaprootWitness<'a> {
+    type Error = TaprootWitnessError;
+
+    fn try_from(witness: &'a Witness) -> Result<Self, Self::Error> {
+        let last = witness
+            .last()
+            .ok_or(TaprootWitnessError::EmptyWitness)?;
+
+        let last_non_annex_index = if last.len() > 0 && last[0] == TAPROOT_ANNEX_PREFIX {
+            witness.len() - 2
+        } else {
+            witness.len() - 1
+        };
+
+        if last_non_annex_index == 0 {
+            let signature = taproot::Signature::from_slice(&witness[0])
+                .map_err(|_| TaprootWitnessError::InvalidSignature)?;
+
+            Ok(TaprootWitness::Keyspend { signature, annex: witness.taproot_annex() })
+        } else {
+            if last_non_annex_index < 1 {
+                return Err(TaprootWitnessError::InvalidWitness);
+            }
+
+            let control_block = ControlBlock::decode(&witness[last_non_annex_index])
+                .map_err(TaprootWitnessError::InvalidControlBlock)?;
+
+            let script = Script::from_bytes(&witness[last_non_annex_index - 1]);
+
+            Ok(TaprootWitness::ScriptSpend {
+                script,
+                control_block,
+                annex: witness.taproot_annex(),
+            })
+        }
+    }
+}
+
+/// The public add_transaction result Ok type
+#[derive(Debug, Eq, PartialEq)]
+pub enum AddTransactionStatus {
+    /// Provided transaction is already tracked in the vault state
+    DuplicateTransaction,
+    /// Provided transaction has been added to the vault state
+    TransactionAdded,
+    /// The provided transaction is irrelevant to this vault
+    TransactionIgnored,
+}
+
+enum OutputInfo {
+    Vault(VaultOutputSpendInfo),
+    Withdrawal(WithdrawalOutputSpendInfo),
+}
+
+#[allow(dead_code)]
+#[derive(Clone, Copy, Eq, PartialEq)]
+enum MatchWildcard {
+    None,
+    AnyDeposit,
+    Anything,
+}
+
+impl MatchWildcard {
+    fn half_merge(&self, a: VaultTransactionMetadata, b: VaultTransactionMetadata) -> Result<VaultTransactionMetadata, ()>
+    {
+        if a == b {
+            return Ok(a);
+        }
+
+        match (a, &b) {
+            (
+                VaultTransactionMetadata::WithdrawalSpend{ withdrawal_vins: mut a_vins },
+                VaultTransactionMetadata::WithdrawalSpend{ withdrawal_vins: b_vins },
+            ) => {
+                a_vins.extend(b_vins.into_iter());
+                return Ok(
+                    VaultTransactionMetadata::WithdrawalSpend{ withdrawal_vins: a_vins }
+                );
+            }
+            _ => { }
+        }
+
+        match (self, b.clone()) {
+            (MatchWildcard::AnyDeposit, VaultTransactionMetadata::InitialDeposit(_)) =>
+                Ok(b),
+            (MatchWildcard::AnyDeposit, VaultTransactionMetadata::Deposit{ .. }) =>
+                Ok(b),
+            _ => Err(()),
+        }
+    }
+
+    fn merge(a: VaultTransactionMetadata, a_wildcard: MatchWildcard, b: VaultTransactionMetadata, b_wildcard: MatchWildcard) -> Result<(VaultTransactionMetadata, MatchWildcard), ()>
+    {
+        let a_result = a_wildcard.half_merge(a.clone(), b.clone());
+        let b_result = b_wildcard.half_merge(b, a);
+
+        let stricter_match = match (a_wildcard, b_wildcard) {
+            (MatchWildcard::AnyDeposit, MatchWildcard::AnyDeposit) => MatchWildcard::AnyDeposit,
+            (MatchWildcard::Anything, MatchWildcard::AnyDeposit) => MatchWildcard::AnyDeposit,
+            (MatchWildcard::AnyDeposit, MatchWildcard::Anything) => MatchWildcard::AnyDeposit,
+            (MatchWildcard::Anything, MatchWildcard::Anything) => MatchWildcard::Anything,
+            _ => MatchWildcard::None,
+        };
+
+        match (a_result, b_result) {
+            (Ok(result), _) => Ok((result, stricter_match)),
+            (_, Ok(result)) => Ok((result, stricter_match)),
+            _ => Err(())
+        }
+    }
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq, Hash, Ord, PartialOrd)]
+pub enum VaultStateOutput {
+    Vault,
+    Withdrawal,
+}
+
+#[derive(Clone, Eq, PartialEq, Hash, Ord, PartialOrd)]
+pub struct VaultStateUtxo(Rc<VaultStateTransaction>, VaultStateOutput);
+
+impl std::fmt::Debug for VaultStateUtxo {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "VaultStateUtxo({}, {:?})", self.0.txid, self.1)
+    }
+}
+
+impl From<(Rc<VaultStateTransaction>, VaultStateOutput)> for VaultStateUtxo {
+    fn from((tx, output): (Rc<VaultStateTransaction>, VaultStateOutput)) -> Self {
+        VaultStateUtxo(tx, output)
+    }
+}
+
+trait VaultUtxos {
+    fn best_vault_utxo(self) -> Option<VaultStateUtxo>;
+}
+
+impl VaultUtxos for &BTreeSet<VaultStateUtxo> {
+    fn best_vault_utxo(self) -> Option<VaultStateUtxo> {
+        // TODO: Do better than just the first
+        self.iter()
+            .filter(|VaultStateUtxo(_tx, output)| match output {
+                VaultStateOutput::Vault => true,
+                _ => false,
+            })
+            .next()
+            .cloned()
+    }
+}
+
+impl ContractInputs for VaultStateTransaction {
+    fn inputs(&self) -> BTreeSet<(u32, OutPoint)> {
+        VaultStateTransaction::input_utxos(self)
+            .into_iter()
+            .map(|(input_index, _utxo)| (
+                input_index,
+                self.transaction.input[input_index as usize].previous_output,
+                )
+            )
+            .collect()
+    }
+}
+
+impl ContractOutputs for VaultStateTransaction {
+    type OutputMetadata = VaultStateOutput;
+
+    fn outputs(&self) -> BTreeMap<u32, Self::OutputMetadata> {
+        VaultStateTransaction::outputs(self)
+            .enumerate()
+            .map(|(vout, metadata)| (vout as u32, metadata))
+            .collect()
+    }
+}
+
+#[derive(Debug)]
+pub enum ConnectVaultTransactionError {
+    Placeholder,
+    InvalidTransaction,
+}
+
+impl ContractTransactionConnector for Context {
+    type Transaction = VaultStateTransaction;
+    type OutputMetadata = VaultStateOutput;
+
+    type Error = ConnectVaultTransactionError;
+
+    fn connect<C: Verification>(&self, secp: &Secp256k1<C>, state: &ChainTipState<Self::Transaction, Self::OutputMetadata>, transaction: &bitcoin::Transaction)
+        -> Result<
+            ConnectTransactionSuccess<Self::Transaction, Self::OutputMetadata>,
+            Self::Error
+        >
+    {
+        let vault_inputs: Vec<_> = transaction.input
+            .iter()
+            .enumerate()
+            .filter_map(|(index, input)| {
+                let tx = state.transaction(input.previous_output.txid)?;
+                let vout = input.previous_output.vout as usize;
+
+                match tx.transaction.output.get(vout) {
+                    // Ignore anchor outputs
+                    Some(txout) => {
+                        if is_ephemeral_anchor(txout) {
+                            return None;
+                        }
+                    }
+                    None => {
+                        return Some(
+                            Err(ConnectVaultTransactionError::InvalidTransaction)
+                        );
+                    }
+                };
+
+                // Ignore spends of recovery txes, key spend txes, and withdrawal spends, spending
+                // of these outputs is outside of our tracking.
+                match tx.metadata {
+                    VaultTransactionMetadata::Recovery { .. } => { return None; }
+                    VaultTransactionMetadata::KeySpend => { return None; }
+                    VaultTransactionMetadata::WithdrawalSpend { .. } => { return None; }
+                    _ => { }
+                }
+
+                Some(Ok((index, input, tx)))
+            })
+            .collect::<Result<_, _>>()?;
+
+        if vault_inputs.is_empty() {
+            // Maybe it's an initial deposit
+            if transaction.output.len() == 1 {
+                if let Some(deposit_amount) = 
+                    self.2.get_initial_deposit_amount(&transaction.output[0]) {
+
+                    let vault_state_transaction = VaultStateTransaction {
+                        txid: transaction.compute_txid(),
+                        transaction: transaction.clone(),
+                        depth: 0,
+                        metadata: VaultTransactionMetadata::InitialDeposit(deposit_amount),
+                        parents:
+                            vault_inputs
+                                .iter()
+                                .map(|(_, _, tx)| (tx.transaction.compute_txid(), (*tx).clone()))
+                                .collect()
+
+                    };
+                    let inputs = vault_state_transaction
+                        .inputs()
+                        .into_iter()
+                        .map(|(_input_index, outpoint)| outpoint)
+                        .collect();
+
+                    let outputs =
+                        ContractOutputs::outputs(&vault_state_transaction);
+
+                    return Ok(
+                        ConnectTransactionSuccess::Connect {
+                            inputs,
+                            transaction: vault_state_transaction,
+                            outputs,
+                        }
+                    );
+                }
+            }
+
+            return Ok(ConnectTransactionSuccess::Ignore);
+        }
+
+        // FIXME: awful name
+        let parent_prevouts: HashMap<_, _> = vault_inputs.iter()
+            .map(|(i, input, input_tx)| (input.previous_output, (*i, input_tx)))
+            .collect();
+
+        let mut parent_metadata: Vec<_> = parent_prevouts
+            .iter()
+            .map(|(prevout, (i, input_tx))| {
+                let vault_state_parameters = input_tx.vault_state_parameters()
+                    .ok_or(ConnectVaultTransactionError::InvalidTransaction)?;
+
+                let next_states = self.1.get_generation(secp, input_tx.depth + 1)
+                    // FIXME: error variant?
+                    // FIXME: a max_depth transaction being spent by a keyspend would probably trip
+                    // this, but it shouldn't
+                    // Actually we wrap next_states in an Option anyway.
+                    // Probably can just ignore if it returns None
+                    .ok_or(ConnectVaultTransactionError::InvalidTransaction)?;
+
+                let spend_conditions = match input_tx.metadata {
+                    VaultTransactionMetadata::InitialDeposit(_amount) => OutputInfo::Vault(
+                        self.0.vault_output(secp, input_tx.depth, &vault_state_parameters, Some(&next_states))
+                    ),
+                    VaultTransactionMetadata::Deposit { .. } => OutputInfo::Vault(
+                        self.0.vault_output(secp, input_tx.depth, &vault_state_parameters, Some(&next_states))
+                    ),
+                    VaultTransactionMetadata::Withdrawal { previous_value, withdrawal } => {
+                        let result_value = previous_value - withdrawal;
+
+                        if result_value > VaultAmount::ZERO {
+                            if prevout.vout == 0 {
+                                OutputInfo::Vault(
+                                    self.0.vault_output(secp, input_tx.depth, &vault_state_parameters, Some(&next_states))
+                                )
+                            } else if prevout.vout == 1 {
+                                OutputInfo::Withdrawal(
+                                    self.0.withdrawal_output_info(secp, input_tx.depth, withdrawal, previous_value - withdrawal)
+                                )
+                            } else {
+                                // FIXME: is it really unreachable? probably should return
+                                // InvalidTransaction instead!
+                                unreachable!()
+                            }
+                        } else {
+                            if prevout.vout == 0 {
+                                OutputInfo::Withdrawal(
+                                    self.0.withdrawal_output_info(secp, input_tx.depth, withdrawal, previous_value - withdrawal)
+                                )
+                            } else {
+                                // FIXME: See above
+                                unreachable!()
+                            }
+                        }
+                    }
+                    VaultTransactionMetadata::WithdrawalSpend { .. } =>
+                        unreachable!("withdrawal spend transactions should be ignored before here"),
+                    VaultTransactionMetadata::Recovery { .. } =>
+                        unreachable!("recovery transactions should be ignored before here"),
+                    VaultTransactionMetadata::KeySpend =>
+                        unreachable!("keyspend transactions should be ignored before here"),
+                };
+
+                let input = transaction.input.get(*i)
+                    .ok_or(ConnectVaultTransactionError::InvalidTransaction)?;
+
+                let witness = TaprootWitness::try_from(&input.witness)
+                    .map_err(|_| ConnectVaultTransactionError::InvalidTransaction)?;
+
+                let metadata = match witness {
+                    TaprootWitness::Keyspend { .. } => 
+                        VaultTransactionMetadata::KeySpend,
+                    TaprootWitness::ScriptSpend { script, control_block, .. } => {
+                        match spend_conditions {
+                            OutputInfo::Vault(conditions) => {
+                                let conditions_lookup = conditions.spend_condition_lookup();
+
+                                let (condition, script_template) = conditions_lookup.get(&control_block.merkle_branch)
+                                    .ok_or(ConnectVaultTransactionError::InvalidTransaction)?;
+
+                                if script_template != script {
+                                    return Err(ConnectVaultTransactionError::InvalidTransaction);
+                                }
+
+                                match condition {
+                                    VaultOutputSpendCondition::Deposit(amount) => {
+                                        let previous_value = input_tx.result_value()
+                                            .ok_or(ConnectVaultTransactionError::InvalidTransaction)?;
+                                        VaultTransactionMetadata::Deposit{ previous_value, deposit: *amount }
+                                    }
+                                    VaultOutputSpendCondition::Withdrawal(amount) => {
+                                        let previous_value = input_tx.result_value()
+                                            .ok_or(ConnectVaultTransactionError::InvalidTransaction)?;
+
+                                        VaultTransactionMetadata::Withdrawal{ previous_value, withdrawal: *amount }
+                                    }
+                                    VaultOutputSpendCondition::Recovery { recovery_type, vault_balance, withdrawal_amount } => {
+                                        let (vault_output_value, withdrawal_output_value) = match recovery_type {
+                                            RecoveryType::VaultOnly => (
+                                                RecoveryInput::Spent(*vault_balance),
+                                                if *withdrawal_amount > VaultAmount::ZERO {
+                                                    RecoveryInput::Ignored(*withdrawal_amount)
+                                                } else {
+                                                    RecoveryInput::None
+                                                },
+                                            ),
+                                            RecoveryType::VaultWithWithdrawal => (
+                                                RecoveryInput::Spent(*vault_balance),
+                                                RecoveryInput::Spent(*withdrawal_amount),
+                                            ),
+                                        };
+
+                                        VaultTransactionMetadata::Recovery {
+                                            vault_output_value,
+                                            withdrawal_output_value
+                                        }
+                                    }
+                                }
+                            }
+                            OutputInfo::Withdrawal(conditions) => {
+                                // XXX: Annoyingly similar to the Deposit arm, but I wasn't able to
+                                // write a function that handled both cases
+                                // Could work around it with a newtype for &Script but that's
+                                // annoying and heavy, and ultimately it's only a few repeated
+                                // lines. If there's a way to use Deref or AsRef to make it work
+                                // though, that would be great...
+                                let conditions_lookup = conditions.spend_condition_lookup();
+
+                                let (condition, script_template) = conditions_lookup.get(&control_block.merkle_branch)
+                                    .ok_or(ConnectVaultTransactionError::InvalidTransaction)?;
+
+                                if *script_template != script {
+                                    return Err(ConnectVaultTransactionError::InvalidTransaction);
+                                }
+
+                                let previous_amount = input_tx.result_value();
+                                let withdrawal_amount = input_tx.withdrawal_amount();
+
+                                match condition {
+                                    WithdrawalSpendingCondition::Recovery =>
+                                        VaultTransactionMetadata::Recovery {
+                                            vault_output_value:
+                                                RecoveryInput::from_amount(
+                                                    previous_amount.expect("dual recovery must have dual outputs"),
+                                                    true,
+                                                ),
+                                            withdrawal_output_value:
+                                                RecoveryInput::from_amount(
+                                                    withdrawal_amount,
+                                                    true,
+                                            ),
+                                        },
+                                    WithdrawalSpendingCondition::RecoveryWithdrawalOnly =>
+                                        VaultTransactionMetadata::Recovery {
+                                            vault_output_value:
+                                                RecoveryInput::from_amount(
+                                                    // FIXME: Concerned that I've made a mistake with how I'm identifying the spending condition. Double check that anything committed to is also accounted for in this
+                                                    previous_amount.unwrap_or(VaultAmount::ZERO),
+                                                    false,
+                                                ),
+                                            withdrawal_output_value:
+                                                RecoveryInput::from_amount(
+                                                    withdrawal_amount,
+                                                    true,
+                                                ),
+                                        },
+                                    WithdrawalSpendingCondition::TimelockedSpend =>
+                                        VaultTransactionMetadata::WithdrawalSpend { withdrawal_vins: iter::once(*i as u32).collect() }
+                                }
+                            },
+                        }
+                    }
+                };
+
+                Ok((*i, prevout, input_tx, metadata, MatchWildcard::None))
+            })
+            .collect::<Result<_, _>>()?;
+
+        parent_metadata.sort_by_key(|(i, _, _, _, _)| *i);
+
+        let (metadata, _) = parent_metadata
+            .iter()
+            .fold(
+                Ok(None),
+                |previous: Result<Option<(VaultTransactionMetadata, _)>, _>, (_, _, _, metadata, wildcard)| {
+                    let previous = previous?;
+
+                    if let Some((previous, previous_wildcard)) = previous {
+                        // FIXME: This doesn't currently allow keyspends, and will probably choke
+                        // on combined spends with multiple 
+                        // MatchWildcard::Anything will permit this, but TODO
+                        MatchWildcard::merge(metadata.clone(), *wildcard, previous, previous_wildcard)
+
+                            .map(|(metadata, wildcard)| Some((metadata, wildcard)))
+                            // FIXME: maybe add an error reason sub-variant
+                            .map_err(|_| ConnectVaultTransactionError::InvalidTransaction)
+                    } else {
+                        Ok(Some((metadata.clone(), *wildcard)))
+                    }
+                }
+            )?
+            .ok_or(ConnectVaultTransactionError::InvalidTransaction)?;
+
+        let depth = parent_metadata
+            .iter()
+            .map(|(_, _, tx, _, _)| tx.depth + 1)
+            .fold(0 as Depth, |a, b| std::cmp::max(a, b));
+
+        let vault_state_transaction = VaultStateTransaction {
+                txid: transaction.compute_txid(),
+                transaction: transaction.clone(),
+                depth,
+                metadata,
+                parents:
+                    vault_inputs
+                        .iter()
+                        .map(|(_, _, tx)| (tx.transaction.compute_txid(), (*tx).clone()))
+                        .collect()
+
             };
 
-            if let Some(history_item) = history_item {
-                self.history.push(history_item);
+        let inputs = vault_state_transaction
+            .inputs()
+            .into_iter()
+            .map(|(_input_index, outpoint)| outpoint);
+        let outputs = ContractOutputs::outputs(&vault_state_transaction);
+
+        Ok(
+            ConnectTransactionSuccess::Connect {
+                inputs: inputs.collect(),
+                transaction: vault_state_transaction,
+                outputs: outputs,
+            }
+        )
+    }
+}
+
+pub struct VaultState(ContractState<VaultStateTransaction, VaultStateOutput>);
+
+impl VaultState {
+    pub(crate) fn new() -> Self { Self(ContractState::new()) }
+}
+
+pub struct Vault {
+    parameters: VaultParameters,
+    state: VaultState,
+}
+
+impl Vault {
+    pub fn new(parameters: VaultParameters, state: VaultState) -> Self {
+        Self {
+            parameters,
+            state,
+        }
+    }
+
+    pub fn new_unpersisted(id: VaultId, parameters: VaultParameters) -> (Self, ChangeLog) {
+        let state = VaultState::new();
+        (
+            Vault::new(parameters, state),
+            ChangeLog::new(id),
+        )
+    }
+
+    pub fn parameters(&self) -> &VaultParameters { &self.parameters }
+
+    /// Return the confirmed balance of the vault by a given height, or any height
+    pub fn confirmed_balance(&self, max_height: Option<u32>) -> Amount {
+        self.state.0.longest_chain_tip()
+            .map(|(_block, state)| {
+                state.utxos(
+                    UtxoSelector::Confirmed(max_height)
+                )
+                .iter()
+                .map(|(_, tx, output, _)| {
+                    match output {
+                        VaultStateOutput::Vault => {
+                            let vault_amount = tx.result_value().unwrap_or(VaultAmount::ZERO);
+
+                            self.parameters.scale.scale_amount(vault_amount)
+                        }
+                        _ => Amount::ZERO,
+                    }
+                })
+                .sum()
+            })
+            .unwrap_or(Amount::ZERO)
+    }
+
+    // FIXME: this should probably be on ContractState
+    #[cfg(feature = "bitcoind")]
+    pub fn apply_block<C: Verification>(&mut self, secp: &Secp256k1<C>, context: &Context, block: &Block, block_height: u32, changelog: &mut ChangeLog) -> Result<(), ApplyBlockError> {
+        let block_hash = block.block_hash();
+        let parent_block_hash = block.header.prev_blockhash;
+
+        let seen_block = self.state.0.add_block(block_height, block_hash, parent_block_hash)
+            .map_err(ApplyBlockError::AddBlockError)?;
+
+        changelog.add(Change::AddBlock { height: block_height, block_hash, parent_block_hash });
+
+        self.state.0.normalize();
+
+        let state = self.state.0.get_tip_mut(&seen_block)
+            .expect("block was just added");
+
+        for transaction in &block.txdata {
+            let txid = transaction.compute_txid();
+            let add_result = state.add(secp, context, txid, transaction, block_height);
+
+            // TODO: Re-evaluate error variants
+            match add_result {
+                Ok(AddTransactionSuccess::TransactionAdded(tx)) => {
+                    changelog.add(Change::AddTransaction(tx.clone()));
+                    changelog.add(Change::Confirm(txid, block_hash, block_height));
+                },
+                Ok(AddTransactionSuccess::TransactionIgnored) => { }
+                Err(AddTransactionError::InternalError) => { return Err(ApplyBlockError::InternalError); },
+                // TODO: Could pass through the connect error, in a new variant, why not?
+                Err(AddTransactionError::ConnectError(_e)) => { return Err(ApplyBlockError::InternalError); }
+                Err(AddTransactionError::MissingInputs) => { return Err(ApplyBlockError::InternalError); }
             }
         }
 
-        return self.history.len();
+        Ok(())
+    }
+
+    fn utxos(&self, selector: UtxoSelector) -> BTreeSet<VaultStateUtxo> {
+        self.state.0.longest_chain_tip()
+            .map(|(_tip, state)| {
+                state.utxos(selector)
+                    .into_iter()
+                    .map(|(_, tx, metadata, _)| VaultStateUtxo(tx, *metadata))
+                    .collect()
+            })
+            .unwrap_or_else(|| BTreeSet::new())
     }
 
     pub fn create_recovery<C: Verification>(&self, secp: &Secp256k1<C>) -> Result<RecoveryTransaction, RecoveryCreationError> {
         // TODO: We need to detect and track which outputs on the last transaction are still unspent
         // For now, just assume the vault has the correct state info (as long as it's been fed recent
         // blocks)
-        let (parent_transaction, _) = self.history.last()
-            .ok_or(RecoveryCreationError::VaultUnopened)?;
-                         //
-        let depth = self.get_current_depth();
-        let parent_depth = depth - 1;
+
+        let utxos = self.utxos(
+            UtxoSelector::any_confirmed(),
+        );
+
+        let utxos = utxos
+            .iter()
+            .filter(|VaultStateUtxo(_tx, output)| match output {
+                VaultStateOutput::Vault => true,
+                VaultStateOutput::Withdrawal => true,
+            });
+
+        let mut sorted_utxos: HashMap<Rc<VaultStateTransaction>, HashSet<VaultStateOutput>> = HashMap::new();
+
+        for utxo in utxos {
+            match sorted_utxos.entry(utxo.0.clone()) {
+                hash_map::Entry::Occupied(mut entry) => { entry.get_mut().insert(utxo.1); }
+                hash_map::Entry::Vacant(entry) => {
+                    entry.insert(
+                        iter::once(utxo.1).collect()
+                    );
+                }
+            }
+        }
+
+        let utxos = sorted_utxos.iter()
+            .map(|(tx, outputs)| {
+                let value = outputs.iter().map(|utxo| {
+                    tx.txout(*utxo)
+                        .expect("valid output type")
+                        .value
+                })
+                .fold(Amount::ZERO, std::ops::Add::add);
+
+                (tx, outputs, value)
+            })
+            .max_by(|a, b| a.2.cmp(&b.2));
+
+        let (tx, _outputs, _value) = utxos.ok_or(RecoveryCreationError::NoOutputs)?;
+
+        let depth = tx.depth + 1;
+        let parent_depth = tx.depth;
+
+        let recovery_key = self.parameters.recovery_key(secp, depth);
 
         if depth > self.parameters.max_depth {
             return Err(RecoveryCreationError::MaxDepth);
         }
 
-        let parent_parameters = self.last_state_parameters()
-            .expect("transaction history must always be valid")
+        let parent_parameters = tx.vault_state_parameters()
             .ok_or(RecoveryCreationError::HistoryError)?;
+
+        let parent_result = tx.result_value()
+            .unwrap_or(VaultAmount::ZERO);
 
         // FIXME: We can do this more efficiently by using `templates` to generate
         // `parent_templates`, but not right now...
@@ -3108,195 +2154,175 @@ impl Vault {
 
         let templates = self.parameters.templates_at_depth(secp, depth);
 
-        let parent_txout = self.parameters.vault_output(
+        // FIXME: This shouldn't be run unconditionally. It will panic for vault states that have
+        // no vault output (complete withdrawals)
+        let parent_output_info = self.parameters.vault_output(
             secp,
             parent_depth,
             &parent_parameters,
             Some(&templates),
         );
 
-        let spend_conditions = self.parameters.vault_output_spend_conditions(secp, parent_depth, &parent_parameters, &templates);
+        match tx.metadata {
+            VaultTransactionMetadata::InitialDeposit(_deposit) => {
+                let vault_signing_info = parent_output_info.get_spending_condition(
+                    VaultOutputSpendCondition::Recovery {
+                        recovery_type: RecoveryType::VaultOnly,
+                        vault_balance: parent_result,
+                        withdrawal_amount: VaultAmount::ZERO,
+                    }
+                )
+                .expect("spend condition should exist");
 
-        let master_key = self.parameters.master_key(secp, parent_depth);
+                Ok(
+                    RecoveryTransaction::new(
+                        secp,
+                        depth,
+                        tx.transaction.compute_txid(),
+                        recovery_key,
+                        RecoveryTransactionInput::VaultOnly(
+                            vault_signing_info,
+                            tx.output_index(VaultStateOutput::Vault)
+                                .expect("deposit must have vault output"),
+                        ),
+                        parent_result,
+                        self.parameters.scale,
+                    )
+                )
+            }
+            VaultTransactionMetadata::Deposit { .. } => {
+                let vault_signing_info = parent_output_info.get_spending_condition(
+                    VaultOutputSpendCondition::Recovery {
+                        recovery_type: RecoveryType::VaultOnly,
+                        vault_balance: parent_result,
+                        withdrawal_amount: VaultAmount::ZERO,
+                    }
+                )
+                .expect("spend condition should exist");
 
-        let spend_info = TaprootBuilder::with_huffman_tree(
-            spend_conditions.iter().map(|(condition, script)| (self.parameters.spend_condition_weight(&condition), script.to_scriptbuf()))
-            )
-            .expect("taproot tree builder")
-            .finalize(secp, master_key)
-            .expect("taproot tree finalize");
+                Ok(
+                    RecoveryTransaction::new(
+                        secp,
+                        depth,
+                        tx.transaction.compute_txid(),
+                        recovery_key,
+                        RecoveryTransactionInput::VaultOnly(
+                            vault_signing_info,
+                            tx.output_index(VaultStateOutput::Vault)
+                                .expect("deposit must have vault output"),
+                        ),
+                        parent_result,
+                        self.parameters.scale,
+                    )
+                )
+            }
+            VaultTransactionMetadata::Withdrawal { withdrawal, previous_value } => {
+                // TODO: We can also derive this from the UTXOs we have, probably would be cleaner,
+                // but I already wrote this code and don't want to think about it more right now
+                let (vault_recovery_type, recovery_amount) = if parent_result > VaultAmount::ZERO && withdrawal > VaultAmount::ZERO {
+                    (Some(RecoveryType::VaultWithWithdrawal), previous_value)
+                } else if parent_result > VaultAmount::ZERO {
+                    (Some(RecoveryType::VaultOnly), previous_value)
+                } else if withdrawal > VaultAmount::ZERO {
+                    (None, withdrawal)
+                } else {
+                    unreachable!("previous transaction must have a nonzero vault or withdrawal output");
+                };
 
-        let vault_spend_info = VaultOutputSpendInfo {
-            spend_info,
-            depth: parent_depth,
-            branches: spend_conditions.into_iter().collect(),
-            output: parent_txout,
-        };
-
-        match &parent_transaction.transition {
-                VaultHistoryTransactionDetails::VaultDeposit { vout, .. } => {
-                    let recovery_tx = self.parameters.recovery_template(secp, depth, parent_transaction.result_value, VaultAmount::ZERO);
-
-                    let branch = vault_spend_info
-                        .branches
-                        .get(&VaultOutputSpendCondition::Recovery {
-                            recovery_type: RecoveryType::VaultOnly,
-                            vault_balance: parent_transaction.result_value,
-                            withdrawal_amount: VaultAmount::ZERO,
-                        })
-                        .expect("spend condition should exist");
-
-                    let control_block = vault_spend_info.spend_info.control_block(&(
-                        branch.to_scriptbuf(),
-                        LeafVersion::TapScript
-                    ))
-                    .expect("if the branch exists so should the control block");
-                    // FIXME: ok we've duplicated the VaultOutput*Info logic in several places now,
-                    // definitely refactor when time permits
-                    let vault_signing_info = VaultOutputSigningInfo {
-                        pubkey: self.parameters.hot_key(&secp, vault_spend_info.depth),
-                        control_block,
-                        vault_prevout: vault_spend_info.output,
-                        script: branch.to_scriptbuf(),
-                    };
-
-                    Ok(
-                        RecoveryTransaction {
-                            depth,
-                            prevout_txid: parent_transaction.txid,
-                            input: RecoveryTransactionInput::VaultOnly(
-                                vault_signing_info,
-                                *vout,
-                            ),
-                            output: recovery_tx.output[0].clone(),
-                            vault_signature: None,
-                            withdrawal_signature: None,
+                let vault_signing_info = if let Some(vault_recovery_type) = vault_recovery_type {
+                    parent_output_info.get_spending_condition(
+                        VaultOutputSpendCondition::Recovery {
+                            recovery_type: vault_recovery_type,
+                            vault_balance: parent_result,
+                            withdrawal_amount: withdrawal,
                         }
                     )
-                }
-                VaultHistoryTransactionDetails::VaultWithdrawal { withdrawal_amount, withdrawal_vout, vault_vout, .. } => {
-                    let recovery_tx = self.parameters.recovery_template(secp, depth, parent_transaction.result_value, *withdrawal_amount);
+                } else {
+                    None
+                };
 
-                    let vault_recovery_type = if parent_transaction.result_value > VaultAmount::ZERO && *withdrawal_amount > VaultAmount::ZERO {
-                        Some(RecoveryType::VaultWithWithdrawal)
-                    } else if parent_transaction.result_value > VaultAmount::ZERO {
-                        Some(RecoveryType::VaultOnly)
-                    } else if *withdrawal_amount > VaultAmount::ZERO {
-                        None
-                    } else {
-                        unreachable!("previous transaction must have a nonzero vault or withdrawal output");
-                    };
+                // FIXME: gross!
+                let withdrawal_prevout = match parent_template {
+                    VaultTransactionTemplate::Deposit(_) => unreachable!("cannot have a deposit template for a withdrawal state"),
+                    VaultTransactionTemplate::Withdrawal(withdrawal) => withdrawal.withdrawal_output.clone(),
+                };
 
-                    let vault_signing_info = if let Some(vault_recovery_type) = vault_recovery_type {
+                // TODO: Did my refactoring work create any opportunity to clean this up?
+                let withdrawal_output_info = self.parameters.withdrawal_output_info(secp, parent_depth, withdrawal, parent_result);
 
-                        let branch = vault_spend_info
-                            .branches
-                            .get(&VaultOutputSpendCondition::Recovery {
-                                recovery_type: vault_recovery_type,
-                                vault_balance: parent_transaction.result_value,
-                                withdrawal_amount: *withdrawal_amount,
-                            })
-                            .expect("spend condition should exist");
+                let withdrawal_script_pubkey = withdrawal_output_info.script_pubkey();
 
-                        let control_block = vault_spend_info.spend_info.control_block(&(
-                            branch.to_scriptbuf(),
-                            LeafVersion::TapScript
-                        ))
-                        .expect("if the branch exists so should the control block");
-                        // FIXME: ok we've duplicated the VaultOutput*Info logic in several places now,
-                        // definitely refactor when time permits
-                        Some(
-                            VaultOutputSigningInfo {
-                                pubkey: self.parameters.hot_key(&secp, vault_spend_info.depth),
-                                control_block,
-                                vault_prevout: vault_spend_info.output,
-                                script: branch.to_scriptbuf(),
-                            }
-                        )
-                    } else {
-                        None
-                    };
+                debug_assert_eq!(withdrawal_script_pubkey, withdrawal_prevout.script_pubkey);
+                let calculated_script_pubkey = ScriptBuf::new_p2tr(secp, withdrawal_output_info.master_pubkey(), Some(withdrawal_output_info.root_node_hash()));
+                debug_assert_eq!(withdrawal_script_pubkey, calculated_script_pubkey);
 
-                    // FIXME: gross!
-                    let withdrawal_prevout = match parent_template {
-                        VaultTransactionTemplate::Deposit(_) => unreachable!("cannot have a deposit template for a withdrawal state"),
-                        VaultTransactionTemplate::Withdrawal(withdrawal) => withdrawal.withdrawal_output.clone(),
-                    };
+                debug_assert_eq!(
+                    self.parameters.master_key(&secp, parent_depth),
+                    withdrawal_output_info.master_pubkey(),
+                );
 
-                    let withdrawal_output_info = self.parameters.withdrawal_output_info(secp, parent_depth, *withdrawal_amount, parent_transaction.result_value);
-
-                    let (output_key, output_key_parity) =
-                        withdrawal_output_info.master_pubkey
-                        .tap_tweak(
-                            secp,
-                            Some(withdrawal_output_info.root_node_hash())
-                        );
-
-                    let withdrawal_script_pubkey = withdrawal_output_info.script_pubkey(secp);
-
-                    debug_assert_eq!(withdrawal_script_pubkey, withdrawal_prevout.script_pubkey);
-                    let calculated_script_pubkey = ScriptBuf::new_p2tr(secp, withdrawal_output_info.master_pubkey, Some(withdrawal_output_info.root_node_hash()));
-                    debug_assert_eq!(withdrawal_script_pubkey, calculated_script_pubkey);
-                    debug_assert_eq!(
-                        withdrawal_script_pubkey,
-                        ScriptBuf::new_p2tr_tweaked(TweakedPublicKey::from(output_key)),
-                    );
-
-                    debug_assert_eq!(
-                        self.parameters.master_key(&secp, parent_depth),
-                        withdrawal_output_info.master_pubkey,
-                    );
-
-
-                    let withdrawal_control_block = ControlBlock {
-                        leaf_version: LeafVersion::TapScript,
-                        output_key_parity,
-                        internal_key: withdrawal_output_info.master_pubkey,
-                        merkle_branch: withdrawal_output_info.recovery_merkle_branch(),
-                    };
-
-                    let withdrawal_signing_info = WithdrawalOutputSigningInfo {
-                        pubkey: withdrawal_output_info.master_pubkey,
-                        control_block: withdrawal_control_block,
-                        vault_prevout: withdrawal_prevout,
-                        script: withdrawal_output_info.double_recovery_script
-                            .map(|script| script.clone())
-                            .unwrap_or_else(|| withdrawal_output_info.single_recovery_script.clone()),
-                    };
-
-                    debug_assert_eq!(withdrawal_script_pubkey, calculated_script_pubkey);
-
-                    let input = if let Some(vault_signing_info) = vault_signing_info {
-                        RecoveryTransactionInput::Withdrawal {
-                            vault: vault_signing_info,
-                            vault_vout: vault_vout.expect("has vault output"),
-                            withdrawal: withdrawal_signing_info,
-                            withdrawal_vout: *withdrawal_vout,
-                        }
-                    } else {
-                        RecoveryTransactionInput::WithdrawalOnly(
-                            withdrawal_signing_info,
-                            0, // FIXME: vout really shouldn't be here
-                        )
-                    };
-
-                    Ok(
-                        RecoveryTransaction {
-                            depth,
-                            prevout_txid: parent_transaction.txid,
-                            input,
-                            output: recovery_tx.output[0].clone(),
-                            vault_signature: None,
-                            withdrawal_signature: None,
-                        }
+                let withdrawal_spending_condition = withdrawal_output_info.get_spending_condition(
+                    WithdrawalSpendingCondition::Recovery,
+                ).
+                unwrap_or(
+                    withdrawal_output_info.get_spending_condition(
+                        WithdrawalSpendingCondition::RecoveryWithdrawalOnly,
                     )
-                }
-                VaultHistoryTransactionDetails::KeySpend {  } => {
-                    return Err(RecoveryCreationError::UnrecoverableLastTransaction);
-                }
-                VaultHistoryTransactionDetails::Recovery { .. } => {
-                    return Err(RecoveryCreationError::UnrecoverableLastTransaction);
-                }
+                    .expect("Withdrawal output will always have a withdrawal-only spend path")
+                );
+
+                let withdrawal_signing_info = withdrawal_output_info
+                    .to_signing_info(secp, withdrawal_prevout.clone(), WithdrawalSpendingCondition::Recovery)
+                    .or_else(|| withdrawal_output_info
+                        .to_signing_info(secp, withdrawal_prevout.clone(), WithdrawalSpendingCondition::RecoveryWithdrawalOnly)
+                    )
+                    .expect("withdrawal output must have either double or single withdrawal spend condition");
+
+                debug_assert_eq!(withdrawal_script_pubkey, calculated_script_pubkey);
+
+                // FIXME: eliminate the other one entirely
+                assert_eq!(
+                    withdrawal_spending_condition,
+                    withdrawal_signing_info,
+                );
+
+                let input = if let Some(vault_signing_info) = vault_signing_info {
+                    RecoveryTransactionInput::Withdrawal {
+                        vault: vault_signing_info,
+                        vault_vout: 
+                            tx.output_index(VaultStateOutput::Vault)
+                                // TODO: I think we can eliminate this pretty easily
+                                .expect("has vault output if we have vault signing info"),
+                        withdrawal: withdrawal_signing_info,
+                        withdrawal_vout: 
+                            tx.output_index(VaultStateOutput::Withdrawal)
+                                .expect("Withdrawal tx has withdrawal output"),
+                    }
+                } else {
+                    RecoveryTransactionInput::WithdrawalOnly(
+                        withdrawal_signing_info,
+                        tx.output_index(VaultStateOutput::Withdrawal)
+                            .expect("Withdrawal tx has withdrawal output"),
+                    )
+                };
+
+                Ok(
+                    RecoveryTransaction::new(
+                        secp,
+                        depth,
+                        tx.transaction.compute_txid(),
+                        recovery_key,
+                        input,
+                        recovery_amount,
+                        self.parameters.scale,
+                    )
+                )
+            }
+
+            // XXX: UTXO filtering above should ensure these are unreachable
+            VaultTransactionMetadata::WithdrawalSpend { .. } => unreachable!(),
+            VaultTransactionMetadata::Recovery { .. } => unreachable!(),
+            VaultTransactionMetadata::KeySpend => unreachable!(),
         }
     }
 
@@ -3308,9 +2334,15 @@ impl Vault {
             return Err(DepositCreationError::InvalidDepositAmount);
         }
 
-        let current_vault_value = self.history
-            .last()
-            .map(|(tx, _)| tx.result_value)
+        let utxos = self.utxos(
+            UtxoSelector::any_confirmed(),
+        );
+
+        let vault_utxo = utxos.best_vault_utxo();
+
+        let current_vault_value = vault_utxo
+            .as_ref()
+            .and_then(|VaultStateUtxo(tx, _)| tx.result_value())
             .unwrap_or(VaultAmount::ZERO);
 
         let result_vault_value = current_vault_value + deposit_amount;
@@ -3325,22 +2357,25 @@ impl Vault {
             }
         }
 
-        let depth = self.get_current_depth();
+        let (parameters, depth, outpoint) = match vault_utxo.as_ref() {
+            Some(VaultStateUtxo(tx, _output)) => {
+                let parent_parameters = tx.vault_state_parameters()
+                    .expect("deposit parent must have valid parameters");
 
-        // TODO: let the caller provide this state
-        let transactions = self.parameters.templates_at_depth(secp, depth);
-
-        let (parameters, outpoint) = match self.history.last() {
-            Some((transaction, _)) => {
-                let outpoint = transaction
-                    .vault_outpoint()
-                    .ok_or(DepositCreationError::VaultClosed)?;
-
+                // FIXME: confirm depth calculation
                 (
-                    transaction
-                        .to_child_parameters(VaultTransition::Deposit(deposit_amount))
-                        .map_err(|_| DepositCreationError::VaultClosed)?,
-                    Some(outpoint),
+                    parent_parameters.next(
+                        VaultTransition::Deposit(deposit_amount),
+                        &self.parameters,
+                        tx.depth + 1,
+                    )
+                    .ok_or(DepositCreationError::VaultClosed)?,
+                    tx.depth + 1,
+                    Some(
+                        tx.outpoint(VaultStateOutput::Vault)
+                            // XXX: I think the expect is a good sanity check here
+                            .expect("must have vault output")
+                    ),
                 )
             }
             None => (
@@ -3349,9 +2384,13 @@ impl Vault {
                     previous_value: VaultAmount(0),
                     parent_transition: None,
                 },
+                0,
                 None,
-            )
+            ),
         };
+
+        // TODO: let the caller provide this state
+        let transactions = self.parameters.templates_at_depth(secp, depth);
 
         let deposit = if let Some(deposit) = transactions.get(&parameters) {
             deposit.clone()
@@ -3369,72 +2408,34 @@ impl Vault {
                     )
                 ),
             VaultTransactionTemplate::Deposit(DepositTransactionTemplate::Deposit(deposit)) => {
-                let spend_info = self.last_state_parameters()
-                    .expect("transaction history must always be valid")
-                    .map(|parent_parameters| {
-                        debug_assert!(depth > 0, "Depth 0 has no ancestors");
+                debug_assert!(depth > 0, "Depth 0 has no ancestors");
 
+                let spend_info = vault_utxo
+                    .as_ref()
+                    .and_then(|VaultStateUtxo(tx, _)| tx.vault_state_parameters())
+                    .map(|parent_parameters| {
                         let parent_depth = depth - 1;
 
                         let parent_templates = self.parameters.templates_at_depth(secp, depth);
 
-                        let parent_txout = self.parameters.vault_output(
+                        self.parameters.vault_output(
                             secp,
                             parent_depth,
                             &parent_parameters,
                             Some(&parent_templates),
-                        );
-
-                        let spend_conditions = self.parameters.vault_output_spend_conditions(secp, parent_depth, &parent_parameters, &parent_templates);
-
-                        let master_key = self.parameters.master_key(secp, parent_depth);
-
-                        let spend_info = TaprootBuilder::with_huffman_tree(
-                                spend_conditions.iter().map(|(condition, script)| (self.parameters.spend_condition_weight(&condition), script.to_scriptbuf()))
-                            )
-                            .expect("taproot tree builder")
-                            .finalize(secp, master_key)
-                            .expect("taproot tree finalize");
-
-                        VaultOutputSpendInfo {
-                            spend_info,
-                            depth: parent_depth,
-                            branches: spend_conditions.into_iter().collect(),
-                            output: parent_txout,
-                        }
+                        )
                     })
+                    // FIXME: consider making an error variant
                     .expect("tail deposits have transaction history");
 
                 let vault_outpoint = outpoint.expect("non-initial deposit must have outpoint of previous vault");
 
-                let branch = spend_info
-                    .branches
-                    .get(&VaultOutputSpendCondition::Deposit(deposit_amount))
-                    .expect("spend condition should exist");
+                let signing_info = spend_info.get_spending_condition(
+                    VaultOutputSpendCondition::Deposit(deposit_amount)
+                )
+                .expect("spend condition should exist");
 
-                // TODO: make control_block construction as lazy as possible
-                // Low priority, especially if it makes something later on need to be fallible when
-                // it wouldn't otherwise be
-                let control_block = spend_info.spend_info.control_block(&(
-                    branch.to_scriptbuf(),
-                    LeafVersion::TapScript
-                ))
-                .expect("if the branch exists so should the control block");
-
-                let signing_info = VaultOutputSigningInfo {
-                    pubkey: self.parameters.hot_key(&secp, spend_info.depth),
-                    control_block,
-                    vault_prevout: spend_info.output,
-                    //depth: spend_info.depth,
-                    script: branch.to_scriptbuf(),
-                };
-
-                let tail_deposit_tx = deposit.intantiate(vault_outpoint, master, signing_info);
-
-                assert_eq!(
-                    branch.next_state_template_hash,
-                    tail_deposit_tx.vault_template_hash(),
-                );
+                let tail_deposit_tx = deposit.instantiate(vault_outpoint, master, signing_info);
 
                 Ok(
                     DepositTransaction::Deposit(tail_deposit_tx)
@@ -3444,88 +2445,41 @@ impl Vault {
         }
     }
 
-    // FIXME: consider how much validation we want to do here. Maybe we should just ensure
-    // self.history is always valid, makes more sense
-    fn history_to_parameters(&self, tx: &VaultHistoryTransaction, parent_tx: Option<&VaultHistoryTransaction>) -> Result<VaultStateParameters, HistoryToParametersError> {
-        let parent_transition = match parent_tx {
-            Some(parent_tx) => Some(
-                parent_tx.transition
-                    .try_into_transition()
-                    .ok_or(HistoryToParametersError::InvalidParentDepth)?
-            ),
-            None => None,
-        };
-
-        let parameters = tx.into_parameters(
-            parent_transition,
-            Some(self.parameters.max)
-        )
-        .and_then(|parameters| self.parameters.validate_parameters(parameters, tx.depth))
-        .ok_or(HistoryToParametersError::InvalidParameters)?;
-
-        if let Some(parent_tx) = parent_tx {
-            if parent_tx.depth + 1 != tx.depth {
-                return Err(HistoryToParametersError::InvalidParentDepth);
-            }
-
-            let transition = &tx.transition
-                .try_into_transition()
-                .ok_or(HistoryToParametersError::InvalidParameters)?;
-
-            let expected_parent_result_value = tx
-                .result_value
-                .apply_transition(
-                    transition.invert(),
-                    Some(self.parameters.max),
-                );
-
-            if let Some(expected_value) = expected_parent_result_value {
-                if expected_value != parent_tx.result_value {
-                    return Err(HistoryToParametersError::InconsistentParameters);
-                }
-            } else {
-                return Err(HistoryToParametersError::InvalidParameters);
-            }
-        }
-
-        Ok(parameters)
-    }
-
-    fn last_state_parameters(&self) -> Result<Option<VaultStateParameters>, HistoryToParametersError> {
-        let parent_tx = if self.history.len() >= 2 {
-            Some(&self.history[self.history.len() - 2].0)
-        } else {
-            None
-        };
-
-        if let Some((ref tx, _)) = self.history.last() {
-            self.history_to_parameters(tx, parent_tx)
-                .map(|parameters| Some(parameters))
-        } else {
-            Ok(None)
-        }
-    }
-
     pub fn create_withdrawal<C: Verification>(&self, secp: &Secp256k1<C>, withdrawal_amount: VaultAmount) -> Result<WithdrawalTransaction, WithdrawalCreationError> {
-        let depth = self.get_current_depth();
+        let utxos = self.utxos(
+            UtxoSelector::any_confirmed(),
+        );
 
-        let transition = VaultTransition::Withdrawal(withdrawal_amount);
-        let current_vault_amount = self.history.last()
-            .map(|(tx, _)| tx.result_value)
+        // TODO: Find smallest UTXO larger than or equal to requested withdrawal
+        let vault_utxo = utxos.best_vault_utxo();
+
+        let current_vault_value = vault_utxo
+            .as_ref()
+            .and_then(|VaultStateUtxo(tx, _)| tx.result_value())
             .unwrap_or(VaultAmount::ZERO);
 
-        let (last_vault_transaction, _) = self.history.last()
-            .ok_or(WithdrawalCreationError::VaultClosed)?;
-
-        let previous_output = last_vault_transaction.vault_outpoint()
-            .ok_or(WithdrawalCreationError::VaultClosed)?;
-
-        let vault_total = current_vault_amount.apply_transition(transition, None)
+        let depth = vault_utxo
+            .as_ref()
+            .map(|VaultStateUtxo(tx, _)| tx.depth + 1)
             .ok_or(WithdrawalCreationError::InsufficientFunds)?;
 
-        let parameters = last_vault_transaction
-            .to_child_parameters(VaultTransition::Withdrawal(withdrawal_amount))
-            .map_err(|_| WithdrawalCreationError::VaultClosed)?;
+        let transition = VaultTransition::Withdrawal(withdrawal_amount);
+
+        let previous_output = vault_utxo
+            .as_ref()
+            .and_then(|VaultStateUtxo(tx, _)| tx.outpoint(VaultStateOutput::Vault))
+            .ok_or(WithdrawalCreationError::VaultClosed)?;
+
+        let vault_total = current_vault_value.apply_transition(transition, None)
+            .ok_or(WithdrawalCreationError::InsufficientFunds)?;
+
+        let parameters = vault_utxo
+            .as_ref()
+            .and_then(|VaultStateUtxo(tx, _)| tx.vault_state_parameters())
+            .and_then(|parameters| parameters
+                .next(VaultTransition::Withdrawal(withdrawal_amount), &self.parameters, depth)
+            )
+            .ok_or(WithdrawalCreationError::VaultClosed)?;
 
         // FIXME: maybe this should return a Result<> instead so I can disambiguate cases
         self.parameters.validate_parameters(parameters, depth)
@@ -3541,8 +2495,8 @@ impl Vault {
             VaultTransactionTemplate::Withdrawal(withdrawal) => withdrawal,
         };
 
-        let spend_info = self.last_state_parameters()
-            .expect("transaction history must always be valid")
+        let spend_info = vault_utxo
+            .and_then(|VaultStateUtxo(tx, _)| tx.vault_state_parameters())
             .map(|parent_parameters| {
                 debug_assert!(depth > 0, "Depth 0 has no ancestors");
 
@@ -3551,53 +2505,17 @@ impl Vault {
                 // TODO: should be able to pass in a cached list
                 let templates = self.parameters.templates_at_depth(secp, depth);
 
-                let parent_txout = self.parameters.vault_output(
+                self.parameters.vault_output(
                     secp,
                     parent_depth,
                     &parent_parameters,
                     Some(&templates),
-                );
-
-                let spend_conditions = self.parameters.vault_output_spend_conditions(secp, parent_depth, &parent_parameters, &templates);
-
-                let master_key = self.parameters.master_key(secp, parent_depth);
-
-                let spend_info = TaprootBuilder::with_huffman_tree(
-                        spend_conditions.iter().map(|(condition, script)| (self.parameters.spend_condition_weight(&condition), script.to_scriptbuf()))
-                    )
-                    .expect("taproot tree builder")
-                    .finalize(secp, master_key)
-                    .expect("taproot tree finalize");
-
-                VaultOutputSpendInfo {
-                    spend_info,
-                    depth: parent_depth,
-                    branches: spend_conditions.into_iter().collect(),
-                    output: parent_txout,
-                }
+                )
             })
             .ok_or(WithdrawalCreationError::MissingSpendInfo)?;
 
-        let branch = spend_info.branches.get(&VaultOutputSpendCondition::Withdrawal(withdrawal_amount))
+        let signing_info = spend_info.get_spending_condition(VaultOutputSpendCondition::Withdrawal(withdrawal_amount))
             .ok_or(WithdrawalCreationError::InvalidWithdrawalAmount)?;
-
-        let control_block = spend_info.spend_info.control_block(&(
-                branch.to_scriptbuf(),
-                LeafVersion::TapScript
-        ))
-        .expect("if the branch exists so should the control block");
-
-        assert_eq!(
-            branch.next_state_template_hash,
-            withdrawal_template.vault_template_hash(),
-        );
-
-        let signing_info = VaultOutputSigningInfo {
-                pubkey: self.parameters.hot_key(&secp, spend_info.depth),
-                control_block,
-                vault_prevout: spend_info.output,
-                script: branch.to_scriptbuf(),
-            };
 
         let withdrawal_output_info = self.parameters.withdrawal_output_info(secp, depth, withdrawal_amount, vault_total);
 
@@ -3607,44 +2525,11 @@ impl Vault {
         Ok(withdrawal)
     }
 
-    pub fn add_transaction(&mut self, tx: VaultTransaction) -> Result<(), ()> {
-        let history_tx = match tx {
-            VaultTransaction::Deposit(deposit) => {
-                if (deposit.common().depth as usize) != self.history.len() {
-                    return Err(());
-                }
+    pub fn context<C: Verification>(&self, secp: &Secp256k1<C>) -> Context {
+        let templates = VaultTemplateCache::new(self.parameters);
+        let cache = AddTransactionStateCache::new(secp, &templates);
 
-                VaultHistoryTransaction {
-                    txid: deposit.compute_txid().map_err(|_| ())?,
-                    depth: deposit.common().depth,
-                    transition: VaultHistoryTransactionDetails::VaultDeposit {
-                        deposit_amount: deposit.common().vault_deposit,
-                        vout: deposit.vout(),
-                    },
-                    result_value: deposit.common().vault_total,
-                }
-            }
-            VaultTransaction::Withdrawal(withdrawal) => {
-                if (withdrawal.depth as usize) != self.history.len() {
-                    return Err(());
-                }
-
-                VaultHistoryTransaction {
-                    txid: withdrawal.compute_txid(),
-                    depth: withdrawal.depth,
-                    transition: VaultHistoryTransactionDetails::VaultWithdrawal {
-                        withdrawal_amount: withdrawal.vault_withdrawal,
-                        vault_vout: withdrawal.vault_vout(),
-                        withdrawal_vout: withdrawal.withdrawal_vout(),
-                    },
-                    result_value: withdrawal.vault_total,
-                }
-            }
-        };
-
-        self.history.push((history_tx, None));
-
-        Ok(())
+        Context(self.parameters, templates, cache)
     }
 
     pub fn to_vault_amount(&self, amount: Amount) -> Result<(VaultAmount, Amount), VaultAmountError> {
@@ -3771,207 +2656,6 @@ mod test {
                 ),
             None,
         );
-    }
-
-    #[test]
-    fn test_history_to_parameters() {
-        let secp = Secp256k1::new();
-        let (cold_xpriv, hot_xpriv) = test_xprivs(&secp, 0);
-
-        let parameters = VaultParameters {
-            scale: VaultScale::from_sat(100_000_000),
-            max: VaultAmount::new(10),
-            cold_xpub: Xpub::from_priv(&secp, &cold_xpriv), //
-            hot_xpub: Xpub::from_priv(&secp, &hot_xpriv),  //
-            delay_per_increment: 36,
-            max_withdrawal_per_step: VaultAmount::new(3),
-            max_deposit_per_step: VaultAmount::new(3),
-            max_depth: 10,
-        };
-
-        let dummy_txid = Txid::from_byte_array([0; 32]);
-
-        let vault = Vault {
-            id: 0,
-            parameters,
-            history: Vec::new(),
-        };
-
-        let result_parameters = vault.history_to_parameters(
-            &VaultHistoryTransaction {
-                txid: dummy_txid,
-                depth: 1,
-                transition:
-                    VaultHistoryTransactionDetails::from_transition(
-                        VaultTransition::Withdrawal(VaultAmount(1)),
-                        VaultAmount(2),
-                    ),
-                result_value: VaultAmount(2),
-            },
-            Some(
-                &VaultHistoryTransaction {
-                    txid: dummy_txid,
-                    depth: 0,
-                    transition:
-                        VaultHistoryTransactionDetails::from_transition(
-                            VaultTransition::Deposit(VaultAmount(1)),
-                            VaultAmount(1),
-                        ),
-                    result_value: VaultAmount(1)
-                }
-            ),
-        );
-
-        result_parameters.expect_err("Gen 0 has no parents");
-
-        let result_parameters = vault.history_to_parameters(
-            &VaultHistoryTransaction {
-                txid: dummy_txid,
-                depth: 0,
-                transition:
-                    VaultHistoryTransactionDetails::from_transition(
-                        VaultTransition::Withdrawal(VaultAmount(1)),
-                        VaultAmount(1),
-                    ),
-                result_value: VaultAmount(1),
-            },
-            None,
-        );
-
-        result_parameters.expect_err("Gen 0 can't be a withdrawal");
-
-        let result_parameters = vault.history_to_parameters(
-            &VaultHistoryTransaction {
-                txid: dummy_txid,
-                depth: 1,
-                transition:
-                    VaultHistoryTransactionDetails::from_transition(
-                        VaultTransition::Withdrawal(VaultAmount(1)),
-                        VaultAmount(0),
-                    ),
-                result_value: VaultAmount(0),
-            },
-            Some(&VaultHistoryTransaction {
-                    depth: 0,
-                    transition:
-                        VaultHistoryTransactionDetails::from_transition(
-                            VaultTransition::Deposit(VaultAmount(1)),
-                            VaultAmount(1),
-                        ),
-                    txid: dummy_txid,
-                    result_value: VaultAmount(1),
-                },
-            ),
-        )
-        .unwrap();
-
-        assert_eq!(
-            result_parameters,
-            VaultStateParameters {
-                transition: VaultTransition::Withdrawal(VaultAmount(1)),
-                previous_value: VaultAmount(1),
-                parent_transition: Some(VaultTransition::Deposit(VaultAmount(1))),
-            },
-        );
-
-        let result_parameters = vault.history_to_parameters(
-            &VaultHistoryTransaction {
-                result_value: VaultAmount(3),
-                depth: 1,
-                transition:
-                    VaultHistoryTransactionDetails::from_transition(
-                        VaultTransition::Withdrawal(VaultAmount(2)),
-                        VaultAmount(3),
-                    ),
-                txid: dummy_txid,
-            },
-            Some(
-                &VaultHistoryTransaction {
-                    result_value: VaultAmount(1),
-                    depth: 0,
-                    transition:
-                        VaultHistoryTransactionDetails::from_transition(
-                            VaultTransition::Deposit(VaultAmount(1)),
-                            VaultAmount(1),
-                        ),
-                    txid: dummy_txid,
-               }
-            ),
-        );
-
-        result_parameters.expect_err("Can't withdraw more than vault total");
-
-        let result_parameters = vault.history_to_parameters(
-            &VaultHistoryTransaction {
-                result_value: VaultAmount(1),
-                depth: 1,
-                transition:
-                    VaultHistoryTransactionDetails::from_transition(
-                        VaultTransition::Withdrawal(VaultAmount(1)),
-                        VaultAmount(1),
-                    ),
-                txid: dummy_txid,
-            },
-            Some(
-                &VaultHistoryTransaction {
-                    result_value: VaultAmount(2),
-                    depth: 0,
-                    transition:
-                        VaultHistoryTransactionDetails::from_transition(
-                            VaultTransition::Deposit(VaultAmount(2)),
-                            VaultAmount(2),
-                        ),
-                    txid: dummy_txid,
-               }
-            ),
-        )
-        .unwrap();
-
-        assert_eq!(
-            result_parameters,
-            VaultStateParameters {
-                transition: VaultTransition::Withdrawal(VaultAmount(1)),
-                previous_value: VaultAmount(2),
-                parent_transition: Some(VaultTransition::Deposit(VaultAmount(2))),
-            },
-        );
-
-        let result_parameters = vault.history_to_parameters(
-            &VaultHistoryTransaction {
-                result_value: VaultAmount(3),
-                depth: 1,
-                transition:
-                    VaultHistoryTransactionDetails::from_transition(
-                        VaultTransition::Deposit(VaultAmount(1)),
-                        VaultAmount(3),
-                    ),
-                txid: dummy_txid,
-            },
-            Some(
-                &VaultHistoryTransaction {
-                    txid: dummy_txid,
-                    depth: 0,
-                    transition:
-                        VaultHistoryTransactionDetails::from_transition(
-                            VaultTransition::Deposit(VaultAmount(2)),
-                            VaultAmount(2),
-                        ),
-                    result_value: VaultAmount(2),
-               }
-            ),
-        )
-        .unwrap();
-
-        assert_eq!(
-            result_parameters,
-            VaultStateParameters {
-                transition: VaultTransition::Deposit(VaultAmount(1)),
-                previous_value: VaultAmount(2),
-                parent_transition: Some(VaultTransition::Deposit(VaultAmount(2))),
-            },
-        );
-
-        // TODO: more tests
     }
 
     #[test]

--- a/src/wallet.rs
+++ b/src/wallet.rs
@@ -19,7 +19,7 @@ use bitcoin::{
     Weight,
 };
 
-use crate::vault::{
+use crate::transaction::{
     DepositTransaction,
     WithdrawalTransaction,
 };

--- a/tests/test_vault.rs
+++ b/tests/test_vault.rs
@@ -37,14 +37,15 @@ use std::thread;
 
 use mccv::{
     AccountId,
+    storage::ChangeLog,
     VaultAmount,
     VaultParameters,
     VaultScale,
     Vault,
     VaultDepositor,
     VaultWithdrawer,
-    vault::SqliteVaultStorage,
     vault::SubmitPackage,
+    vault::Context,
 };
 
 fn test_node_subver(node_index: usize) -> String {
@@ -78,9 +79,10 @@ pub fn update_wallet(wallet: &mut Wallet, client: &Client) {
     }
 }
 
-pub fn update_vault<C: Verification>(secp: &Secp256k1<C>, vault: &mut Vault, emitter: &mut Emitter<&Client>) {
+pub fn update_vault<C: Verification>(secp: &Secp256k1<C>, vault: &mut Vault, context: &Context, changelog: &mut ChangeLog, emitter: &mut Emitter<&Client>) {
     while let Some(block) = emitter.next_block().unwrap() {
-        vault.apply_block(secp, &block.block, block.block_height());
+        vault.apply_block(secp, context, &block.block, block.block_height(), changelog)
+            .expect("success");
     }
 }
 
@@ -269,13 +271,9 @@ fn test_deposit_withdraw() {
     let balance = wallet.balance();
 
     assert_eq!(balance.confirmed.to_sat(), 50 * 100_000_000);
+    let (mut vault, mut changelog) = Vault::new_unpersisted(0, test_parameters);
 
-    let sqlite = rusqlite::Connection::open_in_memory()
-        .expect("open memory wallet should succeed");
-    let mut storage = SqliteVaultStorage::from_connection(sqlite)
-        .expect("initialize vault storage");
-    let mut vault = Vault::create_new(&mut storage, "Test Vault", test_parameters)
-        .expect("create vault");
+    let context = vault.context(&secp);
 
     // ============ Deposit 1 ============
     let mut total_deposit = Amount::ZERO;
@@ -324,10 +322,7 @@ fn test_deposit_withdraw() {
 
     assert_eq!(vault.confirmed_balance(None), Amount::ZERO);
 
-    vault.add_transaction(deposit_transaction.into())
-        .expect("deposit transaction should add cleanly");
-
-    update_vault(&secp, &mut vault, &mut vault_block_emitter);
+    update_vault(&secp, &mut vault, &context, &mut changelog, &mut vault_block_emitter);
 
     assert_eq!(vault.confirmed_balance(None), total_deposit);
 
@@ -362,12 +357,9 @@ fn test_deposit_withdraw() {
         .submit_package(&[&shape_transaction, &transmittable_deposit_transaction])
         .expect("package submission success");
 
-    vault.add_transaction(deposit_transaction.into())
-        .expect("deposit transaction should add cleanly");
-
     generate_to_wallet(&mut wallet, nodes.client(0), 6);
 
-    update_vault(&secp, &mut vault, &mut vault_block_emitter);
+    update_vault(&secp, &mut vault, &context, &mut changelog, &mut vault_block_emitter);
 
     assert_eq!(vault.confirmed_balance(None), total_deposit);
 
@@ -404,9 +396,6 @@ fn test_deposit_withdraw() {
     let transmittable_withdrawal_transaction = withdrawal_transaction.to_signed_transaction()
         .expect("signed tx");
 
-    vault.add_transaction(withdrawal_transaction.clone().into())
-        .expect("can add withdrawal");
-
     nodes.client(0).send_raw_transaction(&transmittable_withdrawal_transaction)
         .expect_err("can't broadcast withdrawal without a cpfp");
 
@@ -418,7 +407,7 @@ fn test_deposit_withdraw() {
         .expect("package submission success");
 
     advance_chain(&secp, &mut wallet, nodes.client(0), 1);
-    update_vault(&secp, &mut vault, &mut vault_block_emitter);
+    update_vault(&secp, &mut vault, &context, &mut changelog, &mut vault_block_emitter);
     assert_eq!(vault.confirmed_balance(None), total_deposit);
 
     let withdrawal_spend = withdrawal_transaction.spend_withdrawal();
@@ -493,7 +482,7 @@ fn test_deposit_withdraw() {
     // XXX: We do *not* add the transaction to the vault, to simulate someone else creating it
 
     let vault_amount = vault.confirmed_balance(None);
-    update_vault(&secp, &mut vault, &mut vault_block_emitter);
+    update_vault(&secp, &mut vault, &context, &mut changelog, &mut vault_block_emitter);
 
     // If the vault is able to reconstruct the vault state from the blockchain the balance should
     // be updated
@@ -523,7 +512,7 @@ fn test_deposit_withdraw() {
         .expect("package submission success");
 
     advance_chain(&secp, &mut wallet, nodes.client(0), 1);
-    update_vault(&secp, &mut vault, &mut vault_block_emitter);
+    update_vault(&secp, &mut vault, &context, &mut changelog, &mut vault_block_emitter);
 
     assert_eq!(Amount::ZERO, vault.confirmed_balance(None));
 }


### PR DESCRIPTION
Finish the refactor from hell. Resolves #6 , #10 , #13 and makes #16 trivial.

- Adds a sparse blockchain data structure
- Completely removes naive transaction based state tracking
    - it was attractive at first, since transactions map onto vault state machine states, but I had to add quite a bit of special handling to account for which vault outputs were spent from a given transaction and it became evident that I was just building a hacky UTXO system that didn't handle multiple UTXOs from separate initial deposits, and struggled to account for vault withdrawals and recoveries.
    - UTXOs are the first class primitives in this new state tracking code.
- Removes special treatment of vault-generated transactions since we now have `ContractTransactionConnector::connect()` which handles connecting confirmed transactions to existing outputs, and this works with incoming blocks too.
- Generalizes the process of identifying contract-relevant transactions and classifying their outputs with the `ContractTransactionConnector` trait
- Because vault-generated transactions are no longer treated specially, we can detect spends that originated outside our control, a critical piece for reacting to unauthorized withdrawals.