### PR TITLE
Make storage more generic and implement load and store

### DIFF
--- a/data/migrations/0001-initial.sql
+++ b/data/migrations/0001-initial.sql
@@ -6,18 +6,104 @@ create table mccv_secret (
 
 create table mccv_vault (
 	id integer primary key,
-	name text
+	name text,
+	scale integer,
+	"max" integer,
+	cold_xpub text,
+	hot_xpub text,
+	delay_per_increment integer,
+	max_withdrawal_per_step integer,
+	max_deposit_per_step integer,
+	max_depth integer
 );
 
-create table mccv_state (
+create table mccv_transaction (
 	vault integer,
-	depth integer,
 	txid blob,
-	vault_txout integer,
-	withdrawal_txout integer,
-	script_pubkey blob,
-	height integer,
-	block blob,
-	primary key (vault, depth),
-	foreign key (vault) references mccv_vault (id)
+	primary key (vault, txid),
+	constraint valid_vault_id
+		foreign key (vault) references mccv_vault (id),
+	constraint valid_txid
+		foreign key (txid) references "transaction" (txid)
+) strict, without rowid;
+
+create table block (
+	block_hash blob not null,
+	parent_block_hash blob,
+	height integer not null,
+	primary key (block_hash),
+	constraint valid_parent_block_hash
+		foreign key (parent_block_hash) references block (block_hash)
+) strict, without rowid;
+
+create view chain_tip (
+	block_hash,
+	height
+) as select
+	block.block_hash,
+	block.height
+from block
+where not exists (
+	select 1
+		from block as child_block
+		where block.block_hash = child_block.parent_block_hash
 );
+
+CREATE INDEX block_by_parent ON block(parent_block_hash);
+
+create unique index unique_genesis_block
+	on block((1))
+	where block_hash is null;
+
+create view chain (
+	chain_tip_hash,
+	block_hash,
+	height
+) as with recursive c (
+	chain_tip_hash,
+	parent_block_hash,
+	block_hash,
+	height
+) as not materialized (
+	select
+		tip.block_hash as chain_tip_hash,
+		block.parent_block_hash as parent_block_hash,
+		tip.block_hash as block_hash,
+		tip.height as height
+	from
+		chain_tip tip
+	join block
+		on block.block_hash = tip.block_hash
+
+	union all
+
+	select
+		c.chain_tip_hash as chain_tip_hash,
+		parent.parent_block_hash as parent_block_hash,
+		parent.block_hash as block_hash,
+		parent.height as height
+	from
+		c
+	join block parent on
+		c.parent_block_hash = parent.block_hash
+) select
+	chain_tip_hash,
+	block_hash,
+	height
+from c;
+
+create table "transaction" (
+	txid blob not null,
+	"transaction" blob not null,
+	primary key (txid)
+) strict, without rowid;
+
+create table transaction_confirmation (
+	txid blob,
+	block_hash blob,
+	primary key (txid, block_hash),
+	foreign key (txid) references "transaction" (txid),
+	foreign key (block_hash) references block (block_hash)
+) strict, without rowid;
+
+-- TODO: indexes

--- a/src/chain.rs
+++ b/src/chain.rs
@@ -5,6 +5,28 @@ use bitcoin::{
     Txid,
 };
 
+#[cfg(test)]
+use bitcoin::{
+    locktime::absolute,
+    Amount,
+    block,
+    CompactTarget,
+    script::PushBytes,
+    ScriptBuf,
+    Sequence,
+    transaction,
+    Transaction,
+    TxIn,
+    TxOut,
+    Witness,
+};
+
+#[cfg(test)]
+use bitcoin::hashes::Hash;
+
+#[cfg(test)]
+use bitcoin::io::Write;
+
 use bitcoin::secp256k1::{
     Secp256k1,
     Verification,
@@ -101,7 +123,51 @@ pub struct SeenBlock<T> {
     /// Most recent important ancestor (will not be pruned)
     important_ancestor: Option<Rc<SeenBlock<T>>>,
 
-    transactions: RefCell<BTreeSet<Rc<T>>>,
+    pub(crate) transactions: RefCell<BTreeSet<Rc<T>>>,
+}
+
+#[cfg(test)]
+fn make_test_block_hash<T>(parent: Option<&SeenBlock<T>>, seed: u64) -> BlockHash {
+    let mut engine = BlockHash::engine();
+
+    let _ = engine.write("TEST_BLOCK_TAG".as_bytes())
+        .expect("hash writes always succeed");
+
+    if let Some(parent) = parent {
+        let _ = engine.write(parent.block_hash.as_byte_array())
+            .expect("hash writes always succeed");
+    }
+
+    let _ = engine.write(&seed.to_be_bytes())
+        .expect("hash writes always succeed");
+
+    BlockHash::from_engine(engine)
+}
+
+#[cfg(test)]
+impl<T> SeenBlock<T>
+where
+    T: Ord,
+{
+    pub fn genesis<I>(transactions: I) -> Rc<Self>
+    where
+        I: IntoIterator<Item = T>
+    {
+        let transactions: BTreeSet<_> = transactions
+                    .into_iter()
+                    .map(|transaction| Rc::new(transaction))
+                    .collect();
+
+        Rc::new(
+            Self {
+                height: 0,
+                block_hash: make_test_block_hash::<T>(None, transactions.len() as u64),
+                parent_hash: BlockHash::from_byte_array([0; 32]),
+                important_ancestor: None,
+                transactions: RefCell::new(transactions),
+            }
+        )
+    }
 }
 
 impl<T> Ord for SeenBlock<T> {
@@ -264,8 +330,19 @@ pub enum RevertConfirmedTransactionError {
     /// Indicates its being reverted before a child transaction
     UtxoSpent,
     Inconsistent,
-    MissingTxid,
+    MissingTxid(Txid),
     MissingInput,
+}
+
+impl std::fmt::Display for RevertConfirmedTransactionError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            RevertConfirmedTransactionError::UtxoSpent => write!(f, "UTXO spent"),
+            RevertConfirmedTransactionError::Inconsistent => write!(f, "Inconsistent"),
+            RevertConfirmedTransactionError::MissingTxid(txid) => write!(f, "Missing TXID: {txid}"),
+            RevertConfirmedTransactionError::MissingInput => write!(f, "Missing input"),
+        }
+    }
 }
 
 #[derive(Debug)]
@@ -274,6 +351,17 @@ pub enum AddBlockError {
     MissingParent(BlockHash),
     RevertConfirmedTransactionError(RevertConfirmedTransactionError),
     AddTransactionError,
+}
+
+impl std::fmt::Display for AddBlockError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            AddBlockError::IrreconcilableHistory => write!(f, "Irreconcilable history"),
+            AddBlockError::MissingParent(block_hash) => write!(f, "Missing parent block {block_hash}"),
+            AddBlockError::RevertConfirmedTransactionError(e) => write!(f, "Revert confirmed transaction error {e}"),
+            AddBlockError::AddTransactionError => write!(f, "Add transaction error"),
+        }
+    }
 }
 
 impl<T, O> ChainTipState<T, O> {
@@ -350,7 +438,7 @@ where
         let transaction = if let Some((transaction, _height)) = self.transactions.get(&txid) {
             transaction.clone()
         } else {
-            return Err(RevertConfirmedTransactionError::MissingTxid);
+            return Err(RevertConfirmedTransactionError::MissingTxid(txid));
         };
 
         let utxos: BTreeSet<_> = utxos(transaction.clone()).collect();
@@ -449,6 +537,16 @@ pub enum AddTransactionError<E> {
     InternalError,
     ConnectError(E),
     MissingInputs,
+}
+
+impl<E: std::fmt::Display> std::fmt::Display for AddTransactionError<E> {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            AddTransactionError::InternalError => write!(f, "Internal error"),
+            AddTransactionError::ConnectError(e) => write!(f, "Connect error: {e}"),
+            AddTransactionError::MissingInputs => write!(f, "Missing inputs"),
+        }
+    }
 }
 
 pub struct ContractState<T, O> {
@@ -624,13 +722,13 @@ where
         };
 
         let block = Rc::new(
-                SeenBlock {
-                    height: new_height,
-                    block_hash: new_chain_tip,
-                    parent_hash,
-                    important_ancestor,
-                    transactions: RefCell::new(BTreeSet::new()),
-                }
+            SeenBlock {
+                height: new_height,
+                block_hash: new_chain_tip,
+                parent_hash,
+                important_ancestor,
+                transactions: RefCell::new(BTreeSet::new()),
+            }
         );
 
         self.blocks.insert(block.block_hash, Rc::downgrade(&block));
@@ -646,7 +744,7 @@ where
         });
 
         // First block is handled specially
-        let tip_state = if block.height == 1 {
+        let tip_state = if block.height == 0 {
             self.chain_tips.add_block(None, block.clone())
         } else if let Some(parent) = parent {
             self.chain_tips.add_block(Some(parent), block.clone())
@@ -779,6 +877,94 @@ where
 }
 
 #[cfg(test)]
+pub(crate) trait TestBlock {
+    fn test_coinbase() -> Transaction {
+        let anyonecanspend = ScriptBuf::from_hex("51")
+            .expect("OP_TRUE is a valid script");
+
+        let mut coinbase_scriptsig = ScriptBuf::new();
+        coinbase_scriptsig
+            .push_slice::<&PushBytes>(
+                "test"
+                    .as_bytes()
+                    .try_into()
+                    .expect("short string is valid pushdata")
+            );
+
+        Transaction {
+            version: transaction::Version::ONE,
+            lock_time: absolute::LockTime::ZERO,
+            input: vec![
+                TxIn {
+                    previous_output: OutPoint {
+                        txid: Txid::from_byte_array([0; 32]),
+                        vout: 0,
+                    },
+                    script_sig: coinbase_scriptsig,
+                    sequence: Sequence::MAX,
+                    witness: Witness::new(),
+                },
+            ],
+            output: vec![
+                TxOut {
+                    value: Amount::from_btc(50.0)
+                        .expect("50BTC is a valid amount"),
+                    script_pubkey: anyonecanspend,
+                }
+            ],
+        }
+    }
+
+    fn test_genesis() -> Self;
+
+    fn test_block(prev_blockhash: BlockHash, time: u32, nonce: u32, txdata: Vec<Transaction>) -> Self;
+
+    fn test_child<T: IntoIterator<Item = Transaction>>(&self, nonce: u32, transactions: T) -> Self;
+}
+
+#[cfg(test)]
+impl TestBlock for Block {
+    fn test_genesis() -> Self {
+        bitcoin::blockdata::constants::genesis_block(&bitcoin::params::REGTEST)
+    }
+
+    fn test_block(prev_blockhash: BlockHash, time: u32, nonce: u32, txdata: Vec<Transaction>) -> Self {
+        let mut initial_block = Block {
+            header: block::Header {
+                version: block::Version::ONE,
+                prev_blockhash,
+                merkle_root: block::TxMerkleNode::from_byte_array([0; 32]),
+                time,
+                bits: CompactTarget::default(),
+                nonce,
+            },
+            txdata,
+        };
+
+        if let Some(merkle_root) = initial_block.compute_merkle_root() {
+            initial_block.header.merkle_root = merkle_root;
+        }
+
+        initial_block
+    }
+
+    fn test_child<T: IntoIterator<Item = Transaction>>(&self, nonce: u32, transactions: T) -> Self {
+        let mut txdata = vec![
+            Self::test_coinbase(),
+        ];
+
+        txdata.extend(transactions);
+
+        Self::test_block(
+            self.block_hash(),
+            self.header.time + 1,
+            nonce,
+            txdata
+        )
+    }
+}
+
+#[cfg(test)]
 mod test {
     // XXX: We abuse the fact there's very little/no validation of blocks and transactions in
     // rust-bitcoin to construct these pseudo-mocks.
@@ -786,16 +972,13 @@ mod test {
     use super::*;
 
     use bitcoin::{
-        Amount,
         block,
-        CompactTarget,
         locktime::absolute,
         Transaction,
         TxIn,
         TxOut,
         transaction,
         ScriptBuf,
-        Sequence,
         Witness,
     };
 
@@ -1063,17 +1246,7 @@ mod test {
     }
 
     fn make_test_genesis() -> Block {
-        Block {
-            header: block::Header {
-                version: block::Version::ONE,
-                prev_blockhash: BlockHash::from_byte_array([0; 32]),
-                merkle_root: block::TxMerkleNode::from_byte_array([0; 32]),
-                time: 0,
-                bits: CompactTarget::default(),
-                nonce: 0,
-            },
-            txdata: vec![],
-        }
+        bitcoin::blockdata::constants::genesis_block(&bitcoin::params::REGTEST)
     }
 
     fn make_test_block_inner(previous: BlockHash, nonce: u32, txdata: Vec<Transaction>) -> Block {
@@ -1220,6 +1393,7 @@ mod test {
 
         assert_eq!(state.chain_tips.0.len(), 0);
 
+        state.apply_block(&secp, &contract.context, &genesis, 0).unwrap();
         state.apply_block(&secp, &contract.context, &block1, 1).unwrap();
         let seen_block1 = state.blocks.get_rc(&block1.block_hash()).unwrap();
         let utxos = get_utxos(&state);
@@ -1275,6 +1449,11 @@ mod test {
 
         let genesis = make_test_genesis();
         let block1 = make_test_block(&genesis, 0, vec![]);
+
+        let _ = contract.state.apply_block(&secp, &contract.context, &genesis, 0)
+            .unwrap();
+        let _ = contract2.state.apply_block(&secp, &contract2.context, &genesis, 0)
+            .unwrap();
 
         let txes = contract.state.apply_block(&secp, &contract.context, &block1, 1)
             .unwrap();

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -5,6 +5,7 @@ mod migrate;
 pub mod storage;
 mod transaction;
 pub mod vault;
+pub mod vault_storage;
 pub mod wallet;
 
 pub use vault::{

--- a/src/main.rs
+++ b/src/main.rs
@@ -60,8 +60,11 @@ use mccv::{
 };
 
 use mccv::storage::{
+    Storage,
+};
+
+use mccv::vault_storage::{
     SqliteStorage,
-    VaultStorage,
 };
 
 fn new_xpriv(network: NetworkKind) -> Xpriv {
@@ -208,7 +211,7 @@ fn main() {
             let mut storage = SqliteStorage::from_connection(sqlite)
                 .expect("initialize vault storage");
 
-            let (vault, changelog) = storage.create_vault(&generate_arg.name, vault_parameters)
+            let (vault, changelog) = storage.create(&generate_arg.name, vault_parameters)
                 .expect("vault creation success");
             /*
             let vault = Vault::create_new(&mut storage, "Default Vault", vault_parameters.clone()).expect("vault create");

--- a/src/migrate.rs
+++ b/src/migrate.rs
@@ -3,14 +3,6 @@ use rusqlite::{
     params,
 };
 
-#[allow(dead_code)]
-pub static VAULT_VERSION_ID: i64 = 1;
-
-#[allow(dead_code)]
-pub static VAULT_MIGRATIONS: [(u32, &str); 1] = [
-    (1, include_str!("../data/migrations/0001-initial.sql")),
-];
-
 #[derive(Debug)]
 pub enum MigrationError {
     InitializationFailed(rusqlite::Error),
@@ -18,12 +10,11 @@ pub enum MigrationError {
     FinalizationFailed(rusqlite::Error),
 }
 
-#[allow(dead_code)]
 fn get_and_clear_migration_version(transaction: &mut Transaction<'_>, id: i64) -> Result<u32, rusqlite::Error> {
     transaction.execute(r#"
         create table
             if not exists
-            mccv_migration_version
+            migration_version
         (
             id integer,
             version integer
@@ -31,17 +22,16 @@ fn get_and_clear_migration_version(transaction: &mut Transaction<'_>, id: i64) -
     "#, [])?;
 
     let version: u32 = transaction
-        .prepare(r#"select version from mccv_migration_version where id = ?"#)?
+        .prepare(r#"select version from migration_version where id = ?"#)?
         .query_map(params![id], |row| row.get(0))?
         .next()
         .unwrap_or(Ok(0))?;
 
-    transaction.execute(r#"delete from mccv_migration_version where id = ?"#, params![id])?;
+    transaction.execute(r#"delete from migration_version where id = ?"#, params![id])?;
 
     Ok(version)
 }
 
-#[allow(dead_code)]
 pub fn migrate(transaction: &mut Transaction<'_>, id: i64, migrations: &[(u32, &str)]) -> Result<(u32, u32), MigrationError> {
     let mut version = get_and_clear_migration_version(transaction, id)
         .map_err(|e| MigrationError::InitializationFailed(e))?;
@@ -57,7 +47,7 @@ pub fn migrate(transaction: &mut Transaction<'_>, id: i64, migrations: &[(u32, &
         }
     }
 
-    transaction.execute(r#"insert into mccv_migration_version (version, id) values (?, ?)"#, params![version, id])
+    transaction.execute(r#"insert into migration_version (version, id) values (?, ?)"#, params![version, id])
         .map_err(MigrationError::FinalizationFailed)?;
 
     Ok((initial_version, version))

--- a/src/storage.rs
+++ b/src/storage.rs
@@ -1,131 +1,18 @@
 use bitcoin::{
     BlockHash,
-    Txid,
 };
 
-use rusqlite;
-
-use crate::vault::{
-    VaultStateTransaction,
+use bitcoin::secp256k1::{
+    Secp256k1,
+    Verification,
 };
 
-use std::ops::{Deref, DerefMut};
 use std::rc::Rc;
 
-use crate::migrate::{
-    MigrationError,
-};
-
-use crate::{
-    Vault,
-    VaultId,
-    VaultParameters,
-};
-
-pub struct SqliteStorage {
-    sqlite: rusqlite::Connection,
-}
-
-#[derive(Debug)]
-pub enum SqliteInitializationError {
-    MigrationError(MigrationError),
-    ConnectionConfigurationError(rusqlite::Error),
-}
-
-#[allow(dead_code)]
-impl SqliteStorage {
-    pub fn from_connection(mut _sqlite: rusqlite::Connection) -> Result<Self, SqliteInitializationError> {
-        todo!()
-    }
-
-    fn store_change(_transaction: &mut rusqlite::Transaction, _vault_id: VaultId, _change: &Change) -> Result<(), StoreError> {
-        todo!()
-    }
-}
-
-impl Deref for SqliteStorage {
-    type Target = rusqlite::Connection;
-
-    fn deref(&self) -> &Self::Target {
-        &self.sqlite
-    }
-}
-
-impl DerefMut for SqliteStorage {
-    fn deref_mut(&mut self) -> &mut Self::Target {
-        &mut self.sqlite
-    }
-}
-
-#[derive(Debug)]
-pub enum StoreError {
-    SqliteError(rusqlite::Error),
-    InvalidState,
-    InternalError,
-}
-
-#[derive(Debug)]
-pub enum LoadError {
-    SqliteError(rusqlite::Error),
-    InvalidState,
-    InternalError,
-    NotFound,
-    InvalidXpub,
-    InvalidWithdrawal,
-    InvalidDeposit,
-}
-
-impl From<rusqlite::Error> for LoadError {
-    fn from(e: rusqlite::Error) -> Self {
-        LoadError::SqliteError(e)
-    }
-}
-
-impl From<rusqlite::types::FromSqlError> for LoadError {
-    fn from(e: rusqlite::types::FromSqlError) -> Self {
-        LoadError::SqliteError(e.into())
-    }
-}
-
-impl std::fmt::Display for LoadError {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        match self {
-            LoadError::SqliteError(e) => e.fmt(f),
-            LoadError::InvalidState => write!(f, "Invalid state"),
-            LoadError::InternalError => write!(f, "Internal error"),
-            LoadError::NotFound => write!(f, "Not found"),
-            LoadError::InvalidXpub => write!(f, "Invalid xpub"),
-            LoadError::InvalidWithdrawal => write!(f, "Invalid withdrawal"),
-            LoadError::InvalidDeposit => write!(f, "Invalid deposit"),
-
-        }
-    }
-}
-
-impl std::error::Error for LoadError {
-    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
-        match self {
-            LoadError::SqliteError(e) => Some(e),
-            _ => None,
-        }
-    }
-
-    fn description(&self) -> &str {
-        "Error loading vault data"
-    }
-}
-
-impl From<rusqlite::Error> for StoreError {
-    fn from(e: rusqlite::Error) -> Self {
-        StoreError::SqliteError(e)
-    }
-}
-
 #[derive(Clone,Debug)]
-#[allow(dead_code)]
-pub(crate) enum Change {
+pub enum Change<T> {
     /// Informs the storage backend or VaultState about the existence of a transaction
-    AddTransaction(Rc<VaultStateTransaction>),
+    AddTransaction(BlockHash, Rc<T>),
 
     /// Informs the storage backend or VaultState about the existence of a block, presumably a relevant one
     AddBlock {
@@ -133,68 +20,61 @@ pub(crate) enum Change {
         block_hash: BlockHash,
         parent_block_hash: BlockHash,
     },
-
-    /// Informs the storage backend or VaultState of a transaction's inclusion in a given block
-    /// Must be issued after AddTransaction and AddBlock for the provided blocks
-    // FIXME: Lose the height from this? Backend and now VaultState can derive height 
-    Confirm(Txid, BlockHash, u32),
-
-    /// Instructs the storage backend to drop metadata related to the given block
-    Unconfirm(BlockHash),
 }
 
-pub struct ChangeLog {
-    id: VaultId,
-    changes: Vec<Change>,
+pub struct ChangeLog<S: Storage> {
+    id: S::Id,
+    changes: Vec<Change<S::Transaction>>,
 }
 
-impl ChangeLog {
-    pub(crate) fn new(id: VaultId) -> Self { Self { id, changes: vec![] } }
+pub struct ChangeIterator<S: Storage>(std::vec::IntoIter<Change<S::Transaction>>);
 
-    pub fn id(&self) -> VaultId { self.id }
+impl<S: Storage> Iterator for ChangeIterator<S> {
+    type Item = Change<S::Transaction>;
 
-    pub(crate) fn add(&mut self, change: Change) {
+    fn next(&mut self) -> Option<Self::Item> {
+        self.0.next()
+    }
+}
+
+impl<S: Storage> ChangeLog<S> {
+    /// Create a new, empty changelog
+    /// Must be used with discipline, creating multiple changelogs with the same
+    /// id may cause unpredictable results
+    pub fn new(id: S::Id) -> Self { Self { id, changes: vec![] } }
+
+    pub fn id(&self) -> S::Id { self.id }
+
+    pub fn add(&mut self, change: Change<S::Transaction>) {
         self.changes.push(change);
     }
 
-    pub fn store<S: VaultStorage>(&mut self, storage: S) -> Result<(), S::StoreError> {
-        let _ = storage.store_vault(&self)?;
-        self.changes = Vec::new();
-        Ok(())
+    pub fn to_iterator(self) -> (ChangeLog<S>, ChangeIterator<S>) {
+        (
+            Self::new(self.id),
+            ChangeIterator(self.changes.into_iter()),
+        )
     }
 }
 
-pub trait VaultStorage {
+pub trait Storage: Sized {
     type StoreError;
     type LoadError;
+    type PruneError;
+    type Id: Clone + Copy;
+    type StaticParameters;
+    type State;
+    type Transaction;
 
-    fn create_vault(self, name: &str, parameters: VaultParameters) -> Result<(Vault, ChangeLog), Self::StoreError>;
+    fn create(&mut self, name: &str, parameters: Self::StaticParameters) -> Result<(Self::State, ChangeLog<Self>), Self::StoreError>;
 
-    fn load_vault(self, id: VaultId) -> Result<(Vault, ChangeLog), Self::LoadError>;
+    fn load<C: Verification>(&mut self, secp: &Secp256k1<C>, id: Self::Id) -> Result<(Self::State, ChangeLog<Self>), Self::LoadError>;
 
-    fn list_vaults(self) -> Result<Vec<(VaultId, String)>, Self::LoadError>;
+    fn list(&mut self) -> Result<Vec<(Self::Id, String)>, Self::LoadError>;
 
     // FIXME: Probably shouldn't be part of a public trait
-    fn store_vault(self, changes: &ChangeLog) -> Result<(), Self::StoreError>;
-}
+    fn store(&mut self, changes: ChangeLog<Self>) -> Result<ChangeLog<Self>, Self::StoreError>;
 
-impl VaultStorage for &mut SqliteStorage {
-    type StoreError = StoreError;
-    type LoadError = LoadError;
-
-    fn create_vault(self, _name: &str, _parameters: VaultParameters) -> Result<(Vault, ChangeLog), Self::StoreError> {
-        todo!()
-    }
-
-    fn load_vault(self, _id: VaultId) -> Result<(Vault, ChangeLog), Self::LoadError> {
-        todo!()
-    }
-
-    fn store_vault(self, _changes: &ChangeLog) -> Result<(), Self::StoreError> {
-        todo!()
-    }
-
-    fn list_vaults(self) -> Result<Vec<(VaultId, String)>, Self::LoadError> {
-        todo!()
-    }
+    /// Prune chain tips and unused blocks below a certain height
+    fn prune(&mut self, height: u32) -> Result<(), Self::PruneError>;
 }

--- a/src/vault.rs
+++ b/src/vault.rs
@@ -76,6 +76,10 @@ use crate::storage::{
     ChangeLog,
 };
 
+use crate::vault_storage::{
+    SqliteStorage,
+};
+
 use crate::cache::{
     AddTransactionStateCache,
     VaultTemplateCache,
@@ -146,6 +150,7 @@ pub enum VaultAmountError {
     OutOfRange,
 }
 
+/// Satoshis per increment
 #[derive(Clone,Copy,Debug,Eq,PartialEq,Serialize,Deserialize)]
 #[serde(transparent)]
 pub struct VaultScale(u32);
@@ -389,6 +394,15 @@ pub(crate) trait VaultTemplates {
 }
 
 pub struct Context(VaultParameters, VaultTemplateCache, AddTransactionStateCache);
+
+impl Context {
+    pub(crate) fn from_parameters<C: Verification>(secp: &Secp256k1<C>, parameters: VaultParameters) -> Context {
+        let templates = VaultTemplateCache::new(parameters);
+        let cache = AddTransactionStateCache::new(secp, &templates);
+
+        Self(parameters, templates, cache)
+    }
+}
 
 // FIXME: Don't love that this had to be public because VaultTemplates is in the public interface.
 // Consider wrapping this in a newtype to protect it.
@@ -1203,11 +1217,11 @@ pub(crate) enum VaultTransactionMetadata {
 
 #[derive(Clone, Debug, Eq, Hash, PartialEq, Ord, PartialOrd)]
 pub struct VaultStateTransaction {
-    txid: Txid,
-    transaction: Transaction,
+    pub(crate) txid: Txid,
+    pub(crate) transaction: Transaction,
     // Depth of vault transaction from initial deposit
-    depth: Depth,
-    metadata: VaultTransactionMetadata,
+    pub(crate) depth: Depth,
+    pub(crate) metadata: VaultTransactionMetadata,
     /// Key: parent txid
     parents: BTreeMap<Txid, Rc<VaultStateTransaction>>,
 }
@@ -1664,6 +1678,15 @@ pub enum ConnectVaultTransactionError {
     InvalidTransaction,
 }
 
+impl std::fmt::Display for ConnectVaultTransactionError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            ConnectVaultTransactionError::Placeholder => write!(f, "Placeholder error"),
+            ConnectVaultTransactionError::InvalidTransaction => write!(f, "Invalid transaction"),
+        }
+    }
+}
+
 impl ContractTransactionConnector for Context {
     type Transaction = VaultStateTransaction;
     type OutputMetadata = VaultStateOutput;
@@ -1990,6 +2013,9 @@ pub struct VaultState(ContractState<VaultStateTransaction, VaultStateOutput>);
 
 impl VaultState {
     pub(crate) fn new() -> Self { Self(ContractState::new()) }
+    #[allow(dead_code)]
+    pub(crate) fn state(&self) -> &ContractState<VaultStateTransaction, VaultStateOutput> { &self.0 }
+    pub(crate) fn state_mut(&mut self) -> &mut ContractState<VaultStateTransaction, VaultStateOutput> { &mut self.0 }
 }
 
 pub struct Vault {
@@ -2005,7 +2031,7 @@ impl Vault {
         }
     }
 
-    pub fn new_unpersisted(id: VaultId, parameters: VaultParameters) -> (Self, ChangeLog) {
+    pub fn new_unpersisted(id: VaultId, parameters: VaultParameters) -> (Self, ChangeLog<SqliteStorage>) {
         let state = VaultState::new();
         (
             Vault::new(parameters, state),
@@ -2040,7 +2066,7 @@ impl Vault {
 
     // FIXME: this should probably be on ContractState
     #[cfg(feature = "bitcoind")]
-    pub fn apply_block<C: Verification>(&mut self, secp: &Secp256k1<C>, context: &Context, block: &Block, block_height: u32, changelog: &mut ChangeLog) -> Result<(), ApplyBlockError> {
+    pub fn apply_block<C: Verification>(&mut self, secp: &Secp256k1<C>, context: &Context, block: &Block, block_height: u32, changelog: &mut ChangeLog<SqliteStorage>) -> Result<(), ApplyBlockError> {
         let block_hash = block.block_hash();
         let parent_block_hash = block.header.prev_blockhash;
 
@@ -2061,8 +2087,7 @@ impl Vault {
             // TODO: Re-evaluate error variants
             match add_result {
                 Ok(AddTransactionSuccess::TransactionAdded(tx)) => {
-                    changelog.add(Change::AddTransaction(tx.clone()));
-                    changelog.add(Change::Confirm(txid, block_hash, block_height));
+                    changelog.add(Change::AddTransaction(block_hash, tx.clone()));
                 },
                 Ok(AddTransactionSuccess::TransactionIgnored) => { }
                 Err(AddTransactionError::InternalError) => { return Err(ApplyBlockError::InternalError); },
@@ -2526,10 +2551,7 @@ impl Vault {
     }
 
     pub fn context<C: Verification>(&self, secp: &Secp256k1<C>) -> Context {
-        let templates = VaultTemplateCache::new(self.parameters);
-        let cache = AddTransactionStateCache::new(secp, &templates);
-
-        Context(self.parameters, templates, cache)
+        Context::from_parameters(secp, self.parameters)
     }
 
     pub fn to_vault_amount(&self, amount: Amount) -> Result<(VaultAmount, Amount), VaultAmountError> {
@@ -2560,7 +2582,7 @@ mod test {
     }
 
     // master xpriv derived from milk sad key,
-    // XXX: copied in two places
+    // XXX: copied in three places
     fn test_xprivs<C: Signing>(secp: &Secp256k1<C>, account: u32) -> (Xpriv, Xpriv) {
         let milk_sad_master = Xpriv::from_str("tprv8ZgxMBicQKsPd1EzCPZcQSPhsotX5HvRDCivA7ASNQFmjWuTsW3WWEwUNKFAZrnD9qpz55rtyLdphqkwRZUqNWYXwSEzd6P4pYvXGByRim3").unwrap();
 

--- a/src/vault_storage.rs
+++ b/src/vault_storage.rs
@@ -1,0 +1,1013 @@
+use bitcoin::{BlockHash, Transaction, Txid};
+use bitcoin::bip32::Xpub;
+use bitcoin::consensus::{Encodable, Decodable};
+use bitcoin::hashes::Hash;
+use bitcoin::secp256k1::{Secp256k1, Verification};
+
+use rusqlite;
+use rusqlite::{
+    params,
+    types::FromSql,
+    types::ToSql,
+    types::ToSqlOutput,
+};
+
+use std::collections::{hash_map, HashMap, HashSet};
+use std::ops::{Deref, DerefMut};
+
+use crate::chain::{
+    AddBlockError, AddTransactionSuccess, AddTransactionError,
+};
+
+use crate::migrate::{
+    migrate,
+    MigrationError,
+};
+
+use crate::storage::{
+    Change,
+    ChangeLog,
+    Storage,
+};
+
+use crate::vault::{
+    ConnectVaultTransactionError,
+    Context,
+    Vault,
+    VaultAmount,
+    VaultId,
+    VaultParameters,
+    VaultScale,
+    VaultState,
+    VaultStateTransaction,
+};
+
+use std::str::FromStr;
+
+#[allow(dead_code)]
+pub static VAULT_VERSION_ID: i64 = 1;
+
+#[allow(dead_code)]
+pub static VAULT_MIGRATIONS: [(u32, &str); 1] = [
+    (1, include_str!("../data/migrations/0001-initial.sql")),
+];
+
+pub struct SqliteStorage {
+    sqlite: rusqlite::Connection,
+}
+
+#[derive(Debug)]
+pub enum SqliteInitializationError {
+    MigrationError(MigrationError),
+    ConnectionConfigurationError(rusqlite::Error),
+    CommitError(rusqlite::Error),
+}
+
+#[allow(dead_code)]
+impl SqliteStorage {
+    pub fn from_connection(mut sqlite: rusqlite::Connection) -> Result<Self, SqliteInitializationError> {
+        {
+            let mut transaction = sqlite.transaction().unwrap();
+
+            migrate(&mut transaction, VAULT_VERSION_ID, &VAULT_MIGRATIONS)
+                .map_err(SqliteInitializationError::MigrationError)?;
+
+            transaction.commit()
+                .map_err(SqliteInitializationError::CommitError)?;
+        }
+
+        Ok(SqliteStorage { sqlite })
+    }
+}
+
+impl Deref for SqliteStorage {
+    type Target = rusqlite::Connection;
+
+    fn deref(&self) -> &Self::Target {
+        &self.sqlite
+    }
+}
+
+impl DerefMut for SqliteStorage {
+    fn deref_mut(&mut self) -> &mut Self::Target {
+        &mut self.sqlite
+    }
+}
+
+#[derive(Debug)]
+pub enum StoreError {
+    SqliteError(rusqlite::Error),
+    InvalidState,
+    InternalError,
+}
+
+#[derive(Debug)]
+pub enum LoadError {
+    SqliteError(rusqlite::Error),
+    InvalidState,
+    InternalError,
+    NotFound,
+    InvalidXpub,
+    InvalidWithdrawal,
+    InvalidDeposit,
+    ConnectError(ConnectVaultTransactionError),
+    AddBlockError(AddBlockError),
+    AddTransactionError(AddTransactionError<ConnectVaultTransactionError>),
+}
+
+impl From<rusqlite::Error> for LoadError {
+    fn from(e: rusqlite::Error) -> Self {
+        LoadError::SqliteError(e)
+    }
+}
+
+impl From<rusqlite::types::FromSqlError> for LoadError {
+    fn from(e: rusqlite::types::FromSqlError) -> Self {
+        LoadError::SqliteError(e.into())
+    }
+}
+
+impl std::fmt::Display for LoadError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            LoadError::SqliteError(e) => e.fmt(f),
+            LoadError::InvalidState => write!(f, "Invalid state"),
+            LoadError::InternalError => write!(f, "Internal error"),
+            LoadError::NotFound => write!(f, "Not found"),
+            LoadError::InvalidXpub => write!(f, "Invalid xpub"),
+            LoadError::InvalidWithdrawal => write!(f, "Invalid withdrawal"),
+            LoadError::InvalidDeposit => write!(f, "Invalid deposit"),
+            LoadError::ConnectError(e) => write!(f, "Error connecting transaction: {e}"),
+            LoadError::AddBlockError(e) => write!(f, "Error adding block: {e}"),
+            LoadError::AddTransactionError(e) => write!(f, "Error adding transaction {e}"),
+        }
+    }
+}
+
+impl std::error::Error for LoadError {
+    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
+        match self {
+            LoadError::SqliteError(e) => Some(e),
+            _ => None,
+        }
+    }
+
+    fn description(&self) -> &str {
+        "Error loading vault data"
+    }
+}
+
+impl From<rusqlite::Error> for StoreError {
+    fn from(e: rusqlite::Error) -> Self {
+        StoreError::SqliteError(e)
+    }
+}
+
+impl ToSql for VaultAmount {
+    fn to_sql(&self) -> rusqlite::Result<ToSqlOutput<'_>> {
+        Ok(self.to_unscaled_amount().into())
+    }
+}
+
+impl FromSql for VaultAmount {
+    fn column_result(value: rusqlite::types::ValueRef<'_>) -> rusqlite::types::FromSqlResult<Self> {
+        let amount: u32 = FromSql::column_result(value)?;
+
+        Ok(VaultAmount::new(amount))
+    }
+}
+
+struct ScopeExit<F: FnOnce()>(Option<F>);
+
+impl<F: FnOnce()> Drop for ScopeExit<F> {
+    fn drop(&mut self) {
+        match self.0.take() {
+            None => {}
+            Some(f) => { f(); }
+        }
+    }
+}
+
+impl<F: FnOnce()> ScopeExit<F> {
+    fn new(f: F) -> Self { Self(Some(f)) }
+}
+
+#[derive(Debug)]
+pub enum PruneError {
+    SqliteError(rusqlite::Error),
+}
+
+impl From<rusqlite::Error> for PruneError {
+    fn from(e: rusqlite::Error) -> Self {
+        PruneError::SqliteError(e)
+    }
+}
+
+/// Topologically sort contract transactions
+fn sorted_transactions(block_transactions: &HashMap<Txid, Transaction>) -> Vec<Txid> {
+    let mut unsorted_parent_counts: HashMap<Txid, usize> = HashMap::new();
+    let mut children: HashMap<Txid, HashSet<Txid>> = block_transactions
+        .iter()
+        .map(|(txid, _transaction)| (*txid, HashSet::new()))
+        .collect();
+
+    let mut current: Vec<Txid> = Vec::new();
+
+    for (txid, transaction) in block_transactions {
+        let mut parent_count = 0;
+        for input in &transaction.input {
+            let parent_txid = &input.previous_output.txid;
+            if block_transactions.contains_key(parent_txid) {
+                children
+                    .get_mut(parent_txid)
+                    .expect("all transactions in this block have an entry")
+                    .insert(*txid);
+
+                parent_count += 1;
+            }
+        }
+
+        if parent_count < 1 {
+            current.push(*txid);
+        } else {
+            unsorted_parent_counts.insert(*txid, parent_count);
+        }
+    }
+
+    let mut ordered_txids: Vec<Txid> = Vec::with_capacity(block_transactions.len());
+
+    while let Some(txid) = current.pop() {
+        ordered_txids.push(txid);
+
+        let children = children.get(&txid)
+            .expect("all transactions accounted for");
+        for child_txid in children {
+            match unsorted_parent_counts.entry(*child_txid) {
+                hash_map::Entry::Occupied(mut entry) => {
+                    // When a transaction references another multiple times
+                    // it must be handled correctly
+                    let reference_count = block_transactions
+                        .get(child_txid)
+                        .expect("must be in input transaction set")
+                        .input
+                        .iter()
+                        .filter(|input| input.previous_output.txid == txid)
+                        .count();
+                    let parent_count = entry.get().saturating_sub(reference_count);
+                    if parent_count == 0 {
+                        entry.remove();
+                        current.push(*child_txid);
+                    } else {
+                        entry.insert(parent_count);
+                    }
+                }
+                hash_map::Entry::Vacant(_) => { }
+            }
+        }
+    }
+
+    assert!(unsorted_parent_counts.is_empty());
+
+    ordered_txids
+}
+
+impl Storage for SqliteStorage {
+    type StoreError = StoreError;
+    type LoadError = LoadError;
+    type PruneError = PruneError;
+
+    type Id = VaultId;
+    type StaticParameters = VaultParameters;
+    type State = Vault;
+    type Transaction = VaultStateTransaction;
+
+    fn create(&mut self, name: &str, parameters: Self::StaticParameters) -> Result<(Self::State, ChangeLog<Self>), Self::StoreError> {
+        let transaction = self.sqlite.transaction()?;
+
+        let id = {
+            let mut insert_vault = transaction.prepare(r#"
+                insert or ignore
+                into mccv_vault (
+                    name,
+                    scale,
+                    "max",
+                    cold_xpub,
+                    hot_xpub,
+                    delay_per_increment,
+                    max_withdrawal_per_step,
+                    max_deposit_per_step,
+                    max_depth
+                ) values ( ?, ?, ?, ?, ?, ?, ?, ?, ? )
+            "#)?;
+
+            insert_vault.execute(
+                params![
+                    name,
+                    parameters.scale.to_sat(),
+                    parameters.max,
+                    parameters.cold_xpub.to_string(),
+                    parameters.hot_xpub.to_string(),
+                    parameters.delay_per_increment,
+                    parameters.max_withdrawal_per_step,
+                    parameters.max_deposit_per_step,
+                    parameters.max_depth,
+                ]
+            )?;
+
+            let id = transaction.last_insert_rowid();
+
+            if id == 0 {
+                return Err(StoreError::InternalError);
+            }
+
+            id
+        };
+
+        transaction.commit()?;
+
+        Ok(
+            (
+                Vault::new(
+                    parameters,
+                    VaultState::new(),
+                ),
+                ChangeLog::new(id as VaultId),
+            )
+        )
+    }
+
+    fn load<C: Verification>(&mut self, secp: &Secp256k1<C>, id: Self::Id) -> Result<(Self::State, ChangeLog<Self>), Self::LoadError> {
+        let transaction = self.sqlite.transaction()?;
+
+        let mut parameters = transaction.prepare(r#"
+            select 
+                scale,
+                "max",
+                cold_xpub,
+                hot_xpub,
+                delay_per_increment,
+                max_withdrawal_per_step,
+                max_deposit_per_step,
+                max_depth
+            from mccv_vault
+            where id = ?
+        "#)?;
+
+        let parameters = parameters.query_map(
+            params![ id ],
+            |row| {
+                let scale: VaultScale = row.get::<_, u32>(0)
+                    .map(|scale| VaultScale::new(scale))?;
+                let max: VaultAmount = row.get(1)?;
+                let cold_xpub: Xpub = parse_column(row, 2)?;
+                let hot_xpub: Xpub = parse_column(row, 3)?;
+                let delay_per_increment: u32 = row.get(4)?;
+                let max_withdrawal_per_step: VaultAmount = row.get(5)?;
+                let max_deposit_per_step: VaultAmount = row.get(6)?;
+                let max_depth: u32 = row.get(7)?;
+
+                Ok(
+                    VaultParameters {
+                        scale,
+                        max,
+                        cold_xpub,
+                        hot_xpub,
+                        delay_per_increment,
+                        max_withdrawal_per_step,
+                        max_deposit_per_step,
+                        max_depth,
+                    }
+                )
+            },
+        )?
+        .next()
+        .ok_or(LoadError::NotFound)?
+        .map_err(LoadError::SqliteError)?;
+
+        let mut query_blocks = transaction.prepare(r#"
+            with
+                longest_chain ( tip_hash )
+                as (
+                    select
+                        block_hash as tip_hash
+                    from chain_tip
+                    order by height desc
+                    limit 1
+                )
+            select
+                block.block_hash,
+                block.parent_block_hash,
+                block.height,
+                conf.txid as txid,
+                tx."transaction"
+            from chain
+            join block
+                on block.block_hash = chain.block_hash
+            left join transaction_confirmation as conf
+                on conf.block_hash = chain.block_hash
+            left join "transaction" as tx
+                on tx.txid = conf.txid
+            left join mccv_transaction as vtx
+                on vtx.txid = conf.txid
+            where
+                chain.chain_tip_hash in longest_chain and
+                case
+                    when vtx.vault = ? then 1 
+                    when vtx.vault is null then 1 
+                    else 0
+                end
+            order by block.height asc
+        "#)?;
+
+        fn hash_column<H: bitcoin::hashes::Hash>(row: &rusqlite::Row<'_>, index: usize) -> rusqlite::Result<H>
+        {
+            let bytes = row
+                .get_ref(index)?
+                .as_bytes()?;
+
+            H::from_slice(bytes)
+                .map_err(|e|
+                    rusqlite::Error::FromSqlConversionFailure(
+                        index,
+                        rusqlite::types::Type::Text,
+                        Box::new(e)
+                    )
+                )
+        }
+
+        fn optional_hash_column<H: bitcoin::hashes::Hash>(row: &rusqlite::Row<'_>, index: usize) -> rusqlite::Result<Option<H>> {
+            let bytes = row
+                .get_ref(index)?
+                .as_bytes_or_null()?;
+
+            bytes
+                .map(|bytes| H::from_slice(bytes))
+                .transpose()
+                .map_err(|e|
+                    rusqlite::Error::FromSqlConversionFailure(
+                        index,
+                        rusqlite::types::Type::Text,
+                        Box::new(e)
+                    )
+                )
+        }
+
+        fn parse_column<T, E>(row: &rusqlite::Row<'_>, index: usize) -> rusqlite::Result<T>
+        where
+            T: FromStr<Err = E>,
+            E: std::error::Error + Send + Sync + 'static,
+        {
+            row
+                .get_ref(index)?
+                .as_str()?
+                .parse()
+                .map_err(|e|
+                    rusqlite::Error::FromSqlConversionFailure(
+                        index,
+                        rusqlite::types::Type::Text,
+                        Box::new(e)
+                    )
+                )
+        }
+
+        let context = Context::from_parameters(secp, parameters);
+        let mut state = VaultState::new();
+
+        // (height, parent_block_hash, block_hash)
+        let mut previous_block: Option<(u32, BlockHash, BlockHash)> = None;
+        let mut block_transactions: HashMap<Txid, Transaction> = HashMap::new();
+
+        let mut rows = query_blocks.query(params![ id ])?;
+
+        while let Some(row) = rows.next()? {
+            let block_hash: BlockHash = hash_column(&row, 0)?;
+            let parent_block_hash: BlockHash = optional_hash_column(&row, 1)?
+                .unwrap_or(BlockHash::from_byte_array([0; 32]));
+            let height: u32 = row.get(2)?;
+            let txid: Option<Txid> = optional_hash_column(&row, 3)?;
+            let transaction = {
+                let blob = row
+                    .get_ref(4)?
+                    .as_bytes_or_null()?;
+                blob.map(|mut blob| Transaction::consensus_decode(&mut blob))
+                    .transpose()
+                    .map_err(|_| LoadError::InvalidState)?
+            };
+
+            if Some((height, parent_block_hash, block_hash)) != previous_block {
+                if let Some((previous_height, previous_parent_block_hash, previous_block_hash)) = previous_block {
+                    let seen_block = state
+                        .state_mut()
+                        .add_block(
+                            previous_height,
+                            previous_block_hash,
+                            previous_parent_block_hash,
+                        )
+                        .map_err(|e| LoadError::AddBlockError(e))?;
+
+                    let tip = state
+                        .state_mut()
+                        .get_tip_mut(&seen_block)
+                        .expect("block was just added");
+
+                    for txid in sorted_transactions(&block_transactions) {
+                        let transaction = block_transactions.get(&txid)
+                            .expect("all txids should be in the block");
+                        let add_result = tip.add(secp, &context, txid, transaction, previous_height);
+                        match add_result {
+                            Ok(AddTransactionSuccess::TransactionAdded(tx)) => {
+                                seen_block.transactions.borrow_mut()
+                                    .insert(tx.clone());
+                            },
+                            Ok(AddTransactionSuccess::TransactionIgnored) => { }
+
+                            // TODO: We should revert changes in case of error
+                            Err(AddTransactionError::InternalError) => { return Err(LoadError::InternalError); },
+                            Err(AddTransactionError::ConnectError(e)) => {
+                                return Err(
+                                    LoadError::AddTransactionError(
+                                        AddTransactionError::ConnectError(e)
+                                    )
+                                );
+                            }
+                            Err(AddTransactionError::MissingInputs) => { return Err(LoadError::InternalError); }
+                        }
+                    }
+                }
+
+                block_transactions = HashMap::new();
+                previous_block = Some((height, parent_block_hash, block_hash));
+            }
+
+            match (txid, transaction) {
+                (Some(txid), Some(transaction)) => {
+                    block_transactions.insert(txid, transaction);
+                }
+                (None, None) => { }
+                _ => unreachable!(),
+            }
+        }
+
+        if let Some((previous_height, previous_parent_block_hash, previous_block_hash)) = previous_block {
+            let seen_block = state
+                .state_mut()
+                .add_block(
+                    previous_height,
+                    previous_block_hash,
+                    previous_parent_block_hash,
+                )
+                .map_err(|e| LoadError::AddBlockError(e))?;
+
+            let tip = state
+                .state_mut()
+                .get_tip_mut(&seen_block)
+                .expect("block was just added");
+
+            for txid in sorted_transactions(&block_transactions) {
+                let transaction = block_transactions.get(&txid)
+                    .expect("all txids should be in the block");
+                let add_result = tip.add(secp, &context, txid, transaction, previous_height);
+                match add_result {
+                    Ok(AddTransactionSuccess::TransactionAdded(tx)) => {
+                        seen_block.transactions.borrow_mut()
+                            .insert(tx.clone());
+                    },
+                    Ok(AddTransactionSuccess::TransactionIgnored) => { }
+
+                    // TODO: We should revert changes in case of error
+                    Err(AddTransactionError::InternalError) => { return Err(LoadError::InternalError); },
+                    Err(AddTransactionError::ConnectError(e)) => {
+                        return Err(
+                            LoadError::AddTransactionError(
+                                AddTransactionError::ConnectError(e)
+                            )
+                        );
+                    }
+                    Err(AddTransactionError::MissingInputs) => { return Err(LoadError::InternalError); }
+                }
+            }
+        }
+
+        Ok(
+            (
+                Vault::new(parameters, state),
+                ChangeLog::new(id),
+            )
+        )
+    }
+
+    fn list(&mut self) -> Result<Vec<(Self::Id, String)>, Self::LoadError> {
+        let transaction = self.sqlite.transaction()?;
+
+        let mut list_query = transaction.prepare(r#"
+            select
+                id,
+                name
+            from mccv_vault
+        "#)?;
+
+        let result = list_query.query_map(
+            params![],
+            |row| {
+                Ok(
+                    (
+                        row.get::<_, Self::Id>(0)?,
+                        row.get::<_, String>(1)?,
+                    )
+                )
+            },
+        )?
+        .map(|row|
+            row.map_err(LoadError::from)
+        )
+        .collect();
+
+        result
+    }
+
+    fn store(&mut self, changes: ChangeLog<Self>) -> Result<ChangeLog<Self>, Self::StoreError> {
+        let transaction = self.sqlite.transaction()?;
+
+        let new_changelog = {
+            let mut insert_transaction = transaction.prepare(r#"
+                insert or ignore
+                into "transaction" (
+                    txid,
+                    "transaction"
+                ) values ( ?, ? )
+            "#)?;
+
+            let mut insert_transaction_confirmation = transaction.prepare(r#"
+                insert or ignore
+                into transaction_confirmation (
+                    txid,
+                    block_hash
+                ) values ( ?, ? )
+            "#)?;
+
+            let vault_id = changes.id();
+            let (new_changelog, changes) = changes.to_iterator();
+
+            for change in changes {
+                match change {
+                    Change::AddTransaction(block_hash, tx) => {
+                        let mut serialized_transaction: Vec<u8> = Vec::new();
+
+                        let txid = tx.transaction.compute_txid();
+                        let _ = tx.transaction.consensus_encode(&mut serialized_transaction)
+                            .map_err(|_| StoreError::InternalError)?;
+
+                        insert_transaction.execute(
+                            params![ txid.as_byte_array(), serialized_transaction ]
+                        )?;
+
+                        insert_transaction_confirmation.execute(
+                            params![
+                                txid.as_byte_array(),
+                                block_hash.as_byte_array(),
+                            ],
+                        )?;
+
+                        transaction.execute(r#"
+                                insert
+                                into mccv_transaction (
+                                    vault,
+                                    txid
+                                ) VALUES ( ?, ? )
+                            "#,
+                            params![
+                                vault_id,
+                                txid.as_byte_array(),
+                            ]
+                        )?;
+                    }
+                    Change::AddBlock { height, block_hash, parent_block_hash } => {
+                        let mut insert_block = transaction.prepare(r#"
+                            insert or ignore
+                            into block (
+                                block_hash, parent_block_hash, height
+                            ) values ( ?, ?, ? )
+                        "#)?;
+
+                        let parent_block_hash = if height > 0 {
+                            Some(parent_block_hash.as_byte_array())
+                        } else {
+                            None
+                        };
+
+                        insert_block.execute(params![
+                            block_hash.as_byte_array(),
+                            parent_block_hash,
+                            height
+                        ])?;
+                    }
+                }
+            }
+
+            new_changelog
+        };
+
+        transaction.commit()?;
+
+        Ok(new_changelog)
+    }
+
+    fn prune(&mut self, height: u32) -> Result<(), Self::PruneError> {
+        let transaction = self.sqlite.transaction()?;
+
+        transaction.execute(
+            r#"
+                create temp table saved_block (
+                    block_hash blob primary key
+                )
+            "#,
+            [],
+        )?;
+
+        let mut cleanup_error: Option<rusqlite::Error> = None;
+
+        {
+            let _cleanup = ScopeExit::new(
+                || {
+                    let result = transaction.execute(
+                        r#"
+                            drop table if exists saved_block
+                        "#,
+                        [],
+                    );
+
+                    match result {
+                        Ok(_) => {}
+                        Err(e) => {
+                            cleanup_error = Some(e);
+                        }
+                    }
+                }
+            );
+
+            let _ = transaction.execute(
+                r#"
+                with retained_chain_tip ( chain_tip_hash ) as (
+                    select
+                        block_hash
+                    from chain_tip
+                    where height >= ?
+                )
+                insert or ignore into saved_block (
+                    block_hash
+                ) values (
+                    select
+                        chain.block_hash
+                    from
+                        chain
+                    where
+                        chain.chain_tip_hash in retained_chain_tip
+                )
+                "#,
+                params![ height ],
+            )?;
+
+            transaction.execute(
+                r#"
+                    delete from block
+                    where
+                        block.block_hash not in
+                            ( select block_hash from saved_block )
+                "#,
+                [],
+            )?;
+        }
+
+        transaction.commit()?;
+
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+
+    use bitcoin::{Block, locktime::absolute, OutPoint, transaction, TxIn, TxOut, ScriptBuf, Sequence, Witness};
+    use bitcoin::bip32::{
+        Xpriv,
+    };
+
+    use bitcoin::secp256k1::{
+        Signing,
+    };
+
+    use crate::chain::{TestBlock};
+    use crate::vault::AccountId;
+
+    #[test]
+    fn test_migrate() {
+        let mut connection = rusqlite::Connection::open_in_memory().unwrap();
+
+        let mut transaction = connection.transaction().unwrap();
+
+        migrate(&mut transaction, VAULT_VERSION_ID, &VAULT_MIGRATIONS).unwrap();
+    }
+
+    // master xpriv derived from milk sad key,
+    // XXX: copied in three places
+    fn test_xprivs<C: Signing>(secp: &Secp256k1<C>, account: u32) -> (Xpriv, Xpriv) {
+        let milk_sad_master = Xpriv::from_str("tprv8ZgxMBicQKsPd1EzCPZcQSPhsotX5HvRDCivA7ASNQFmjWuTsW3WWEwUNKFAZrnD9qpz55rtyLdphqkwRZUqNWYXwSEzd6P4pYvXGByRim3").unwrap();
+
+        let account = AccountId::new(account)
+            .expect("Valid account");
+
+        (
+            milk_sad_master
+                .derive_priv(secp, &account.to_cold_derivation_path())
+                .expect("success"),
+            milk_sad_master
+                .derive_priv(secp, &account.to_hot_derivation_path())
+                .expect("success"),
+        )
+    }
+
+    fn test_parameters<C: Signing>(secp: &Secp256k1<C>) -> VaultParameters {
+        let (cold_xpriv, hot_xpriv) = test_xprivs(secp, 0);
+
+        VaultParameters {
+            scale: VaultScale::from_sat(100_000_000),
+            max: VaultAmount::new(10),
+            cold_xpub: Xpub::from_priv(&secp, &cold_xpriv), //
+            hot_xpub: Xpub::from_priv(&secp, &hot_xpriv),  //
+            delay_per_increment: 36,
+            max_withdrawal_per_step: VaultAmount::new(3),
+            max_deposit_per_step: VaultAmount::new(3),
+            max_depth: 10,
+        }
+    }
+
+    #[test]
+    fn test_create_list() {
+        let secp = Secp256k1::new();
+
+        let mut storage = SqliteStorage::from_connection(
+                rusqlite::Connection::open_in_memory().unwrap()
+            )
+            .unwrap();
+
+        let parameters = test_parameters(&secp);
+
+        let (_vault, changelog) = storage.create("test", parameters).unwrap();
+        let (_vault2, changelog2) = storage.create("test2", parameters).unwrap();
+        let (_vault3, changelog3) = storage.create("test3", parameters).unwrap();
+
+        let list = storage.list().unwrap();
+
+        assert_eq!(
+            list,
+            vec![
+                (changelog.id(), "test".to_string()),
+                (changelog2.id(), "test2".to_string()),
+                (changelog3.id(), "test3".to_string()),
+            ],
+        );
+    }
+
+    #[test]
+    fn test_sorted_transactions() {
+        fn txid(x: u8) -> Txid {
+            Txid::from_byte_array([x; 32])
+        }
+
+        let a_txid = txid(0xAA);
+        let b_txid = txid(0xBB);
+        let c_txid = txid(0xCC);
+        let d_txid = txid(0xDD);
+        let e_txid = txid(0xEE);
+        let f_txid = txid(0xFF);
+
+        fn tx<I: IntoIterator<Item = Txid>>(inputs: I) -> Transaction {
+            Transaction {
+                version: transaction::Version::non_standard(3),
+                lock_time: absolute::LockTime::ZERO,
+                input: inputs
+                    .into_iter()
+                    .map(|txid| TxIn {
+                        previous_output: OutPoint {
+                            txid,
+                            // XXX: vout doesn't matter because outputs
+                            // are irrelevant to this function
+                            vout: 0,
+                        },
+                        sequence: Sequence::ZERO,
+                        script_sig: ScriptBuf::new(),
+                        witness: Witness::new(),
+                    })
+                    .collect(),
+                // XXX: Outputs don't matter at all here
+                output: vec![],
+            }
+        }
+
+        let a_tx = tx([ txid(01), txid(02) ]);
+        let b_tx = tx([ a_txid, a_txid ]);
+        let c_tx = tx([ b_txid ]);
+        let d_tx = tx([ a_txid, c_txid ]);
+        let e_tx = tx([ d_txid ]);
+        let f_tx = tx([ txid(01), txid(03) ]);
+
+        let block_transactions: HashMap<_, _> = [
+                (a_txid, a_tx),
+                (b_txid, b_tx),
+                (c_txid, c_tx),
+                (d_txid, d_tx),
+                (e_txid, e_tx),
+                (f_txid, f_tx),
+            ]
+            .into_iter()
+            .collect();
+
+        let sorted = sorted_transactions(&block_transactions);
+
+        for (index, txid) in sorted.iter().enumerate() {
+            let tx = block_transactions.get(txid).unwrap();
+            for input in &tx.input {
+                let parent_index = sorted
+                    .iter()
+                    .position(|parent_txid| *parent_txid == input.previous_output.txid);
+
+                if let Some(parent_index) = parent_index {
+                    assert!(parent_index < index);
+                }
+            }
+
+        }
+    }
+
+    #[test]
+    fn test_store_load() {
+        let secp = Secp256k1::new();
+
+        let mut storage = SqliteStorage::from_connection(
+                rusqlite::Connection::open_in_memory().unwrap()
+            )
+            .unwrap();
+
+        let parameters = test_parameters(&secp);
+
+        let (mut vault, mut changelog) = storage.create("test", parameters).unwrap();
+
+
+        let (vault2, _changelog2) = storage.load(&secp, changelog.id()).unwrap();
+
+        assert_eq!(
+            vault.parameters(),
+            vault2.parameters(),
+        );
+
+        let mut deposit = vault.create_deposit(&secp, VaultAmount::new(1)).unwrap();
+
+        let deposit_prevout = OutPoint {
+            txid: Txid::from_byte_array([1; 32]),
+            vout: 0,
+        };
+
+        let deposit_txout = TxOut {
+            value: parameters.scale.scale_amount(VaultAmount::new(1)),
+            script_pubkey: ScriptBuf::from_hex("51").unwrap(), // OP_1 (anyone can spend)
+        };
+
+        deposit.connect_input(&secp, deposit_prevout, deposit_txout);
+
+        let genesis = Block::test_genesis();
+
+        let signed_deposit = deposit.to_signed_transaction()
+            .unwrap();
+
+        let block1 = genesis.test_child(
+            0,
+            vec![signed_deposit],
+        );
+
+        let context = vault.context(&secp);
+
+        vault.apply_block(&secp, &context, &genesis, 0, &mut changelog)
+            .unwrap();
+
+        vault.apply_block(&secp, &context, &block1, 1, &mut changelog)
+            .unwrap();
+
+        let mut changelog = storage.store(changelog).unwrap();
+
+        let (vault2, _changelog2) = storage.load(&secp, changelog.id()).unwrap();
+
+        assert_eq!(
+            vault.confirmed_balance(None),
+            vault2.confirmed_balance(None),
+        );
+
+        let block2 = block1.test_child(
+            0,
+            vec![],
+        );
+
+        vault.apply_block(&secp, &context, &block2, 2, &mut changelog)
+            .unwrap();
+    }
+}

--- a/tests/test_vault.rs
+++ b/tests/test_vault.rs
@@ -31,13 +31,10 @@ use bitcoin::secp256k1::{
 
 use bitcoin::secp256k1::rand::{RngCore, thread_rng};
 
-use std::str::FromStr;
-use std::time;
-use std::thread;
-
 use mccv::{
     AccountId,
     storage::ChangeLog,
+    storage::Storage,
     VaultAmount,
     VaultParameters,
     VaultScale,
@@ -46,7 +43,12 @@ use mccv::{
     VaultWithdrawer,
     vault::SubmitPackage,
     vault::Context,
+    vault_storage::SqliteStorage,
 };
+
+use std::str::FromStr;
+use std::time;
+use std::thread;
 
 fn test_node_subver(node_index: usize) -> String {
     format!("mccv_testnode{node_index}")
@@ -79,7 +81,7 @@ pub fn update_wallet(wallet: &mut Wallet, client: &Client) {
     }
 }
 
-pub fn update_vault<C: Verification>(secp: &Secp256k1<C>, vault: &mut Vault, context: &Context, changelog: &mut ChangeLog, emitter: &mut Emitter<&Client>) {
+pub fn update_vault<C: Verification>(secp: &Secp256k1<C>, vault: &mut Vault, context: &Context, changelog: &mut ChangeLog<SqliteStorage>, emitter: &mut Emitter<&Client>) {
     while let Some(block) = emitter.next_block().unwrap() {
         vault.apply_block(secp, context, &block.block, block.block_height(), changelog)
             .expect("success");
@@ -236,7 +238,6 @@ impl TestNodes {
 //   - clawback withdrawal UTXO only
 //   - clawback both UTXOs simultaneously
 // - load and store
-// - reorgs
 
 #[test]
 fn test_deposit_withdraw() {
@@ -271,9 +272,19 @@ fn test_deposit_withdraw() {
     let balance = wallet.balance();
 
     assert_eq!(balance.confirmed.to_sat(), 50 * 100_000_000);
-    let (mut vault, mut changelog) = Vault::new_unpersisted(0, test_parameters);
+
+    let mut storage = SqliteStorage::from_connection(
+            rusqlite::Connection::open_in_memory().unwrap()
+        )
+        .unwrap();
+
+    let (mut vault, mut changelog) = storage.create("test", test_parameters)
+        .unwrap();
 
     let context = vault.context(&secp);
+
+    let regtest_genesis = bitcoin::blockdata::constants::genesis_block(&bitcoin::params::REGTEST);
+    vault.apply_block(&secp, &context, &regtest_genesis, 0, &mut changelog).unwrap();
 
     // ============ Deposit 1 ============
     let mut total_deposit = Amount::ZERO;
@@ -479,9 +490,17 @@ fn test_deposit_withdraw() {
 
     advance_chain(&secp, &mut wallet, nodes.client(0), 1);
 
-    // XXX: We do *not* add the transaction to the vault, to simulate someone else creating it
-
     let vault_amount = vault.confirmed_balance(None);
+
+    let mut changelog = storage.store(changelog).unwrap();
+    let (vault2, _) = storage.load(&secp, changelog.id())
+        .unwrap();
+
+    assert_eq!(
+        vault2.confirmed_balance(None),
+        vault_amount,
+    );
+
     update_vault(&secp, &mut vault, &context, &mut changelog, &mut vault_block_emitter);
 
     // If the vault is able to reconstruct the vault state from the blockchain the balance should


### PR DESCRIPTION
- Make `ChangeLog` generic and decoupled from just the vault
- Remove references to "Vault" in the storage trait
- Implement SQLite storage for Vault
  - Store Vault Metadata (parameters)
  - Store Blocks ( block hash, prev block hash, height, relevant transactions )
  - Load Vault Metadata
  - Load Blocks and relevant translations ( replay blocks and their transactions into the vault )
- Implement Stored Blockchain pruning to purge blocks below a certain height that do not contain transactions relevant to the vault

Because contract transaction loading is built around replaying already seen blocks and contract transactions, it shouldn't take much effort to decouple it completely from the vault code. It'd make me feel gross but Contract metadata (parameters) could easily be stored in a json string field transparently and the whole SQLite backend could be pretty easily made completely agnostic to the contract.

Closes #11 