### PR TITLE
cli: Error if network is not signet or regtest

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -647,6 +647,21 @@ fn main() {
 
     let secp = Secp256k1::new();
 
+    assert!(
+        args.network != Network::Bitcoin,
+        "mainnet is not supported!",
+    );
+
+    assert!(
+        args.network != Network::Testnet,
+        "Testnet is not supported!",
+    );
+
+    assert!(
+        args.network != Network::Testnet4,
+        "Testnet4 is not supported!",
+    );
+
     match args.command {
         Command::Generate(ref generate_arg) => {
             let mut rng = thread_rng();


### PR DESCRIPTION
`OP_CHECKTEMPLATEVERIFY` is not supported on mainnet, testnet4, nor testnet3.