### PR TITLE
Update cargo install command in user guide

### DIFF
--- a/docs/user-guide.md
+++ b/docs/user-guide.md
@@ -41,7 +41,7 @@ The first step to trying out the vault is to clone this repository and build it.
 ```
 git clone https://github.com/LNHANCE-Expedition/mccv.git
 cd mccv
-cargo install -F bitcoind
+cargo install --path . --features bitcoind
 ```
 
 This will install the `mccv` command line tool.


### PR DESCRIPTION
I got the following error when trying to install with `cargo install -F bitcoind` 

```bash
➜  mccv git:(master) cargo install -F bitcoind
error: Using `cargo install` to install the binaries from the package in current working directory is no longer supported, use 
`cargo install --path .` instead. Use `cargo build` if you want to simply build the package.
```

I think there has been a cargo update that requires --path now, so this PR updates the docs to use that. Was able to build with `cargo install --path . --features bitcoind`