### PR TITLE
Probe bitcoind before creating vault DB

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+target/
+mccv-vault.sqlite-*
+mccv-wallet.sqlite-*

--- a/src/main.rs
+++ b/src/main.rs
@@ -664,6 +664,14 @@ fn main() {
 
     match args.command {
         Command::Generate(ref generate_arg) => {
+            let rpc_client = generate_arg.rpc_conf.open();
+            let blockchain_info = rpc_client.get_blockchain_info()
+                .expect("RPC success");
+            assert!(
+                !blockchain_info.initial_block_download,
+                "Bitcoin Core is still in initial block download",
+            );
+
             let mut rng = thread_rng();
 
             let mut seed = [0u8; 128];
@@ -716,8 +724,6 @@ fn main() {
                 .expect("vault apply genesis");
 
             vault.vault_changelog = vault.storage.vault_storage.store(vault.vault_changelog.take()).expect("store vault");
-
-            let rpc_client = generate_arg.rpc_conf.open();
 
             let latest_block = latest_blockid(&rpc_client);
             let checkpoint_start = block_parent(&rpc_client, latest_block, 6);


### PR DESCRIPTION
I ran the generate command with my signet node turned off by mistake but then it still created the database, so when i ran the command again, after the node was turned on, it failed. 

This makes the`generate` command query bitcoind with `getblockchaininfo` before opening/creating the vault database

Also good to check if we are in IBD as if we run the `generate` command against the node before its ready, `latest_blockid(&rpc_client);` will save the wrong block height


```bash
  mccv git:(master) mccv generate \
    --vault-name test \
    --scale 10000sat \
    --max 10 \
    --delay 3 \
    --max-deposit 4 \
    --max-withdrawal 3 \
    --max-depth 10 \
    "${RPC_ARGS[@]}"
Xpub: tpubD6NzVbkrYhZ4YiD8LKWrA2f8y7zzmYYwjdcRv4JAvzsPemNL7TH8g56zYt71FATfS91r9QgWUH1LDqJkbVzhbaGZxT1nB1SFfAVPnZiDoAe
Xpriv: tprv8ZgxMBicQKsPfFBLSfrFkd12Q6V4cDN3AL1edYFsWj4zpH7ZV4TYVaV8NjPSixm4MFjh3472AXDu1EAZTFuQMhAKhYr6UgMgb4DvKnxtQGN
Creating Vault...
Generating Vault (this may take a while)...

thread 'main' (7686789) panicked at src/main.rs:327:33:
RPC success: JsonRpc(Transport(SocketError(Os { code: 61, kind: ConnectionRefused, message: "Connection refused" })))
```

```bash
➜  mccv git:(master) ✗ mccv generate \
    --vault-name test \
    --scale 10000sat \
    --max 10 \
    --delay 3 \
    --max-deposit 4 \
    --max-withdrawal 3 \
    --max-depth 10 \
    "${RPC_ARGS[@]}"
Xpub: tpubD6NzVbkrYhZ4WRxwreMDXyfGFhVmHeeQco4kVCLPuUMRePuAfURiHi584rTraxrbXM818WrSxacEyQrWetsBaS1BXypU5xJxk9w2QC6zMxn
Xpriv: tprv8ZgxMBicQKsPcxw9xzgd8a19gfyq8KTW3VTyCgJ6VCZ2oueQ35c87DTFtjfURmsrL6fTHNhVX9Ph9qVgCJPUkQ4zFhgqhNFqF8kU5axW8f2

thread 'main' (7687060) panicked at src/main.rs:469:14:
wallet create: DataAlreadyExists(ChangeSet { descriptor: Some(tr(XPub(DescriptorXKey { origin: Some((fb658367, 86'/1'/0')), xkey: Xpub { network: Test, depth: 3, parent_fingerprint: 267d48b7, child_number: Hardened { index: 0 }, public_key: PublicKey(051adcb11423a210de52ee4833d8c22dc4e1708a4b8a321580a56888d2c9cc5f9ae721d3eba5f25ba05963c0cb7e6c572d4c727a4daf14cd0cb07fb7566fb936), chain_code: f65a6c313df7c87003e5f284966e982e83a8a11ff4a5e7cf543d3176f991ba1b }, derivation_path: 0, wildcard: Unhardened }))), change_descriptor: Some(tr(XPub(DescriptorXKey { origin: Some((fb658367, 86'/1'/0')), xkey: Xpub { network: Test, depth: 3, parent_fingerprint: 267d48b7, child_number: Hardened { index: 0 }, public_key: PublicKey(051adcb11423a210de52ee4833d8c22dc4e1708a4b8a321580a56888d2c9cc5f9ae721d3eba5f25ba05963c0cb7e6c572d4c727a4daf14cd0cb07fb7566fb936), chain_code: f65a6c313df7c87003e5f284966e982e83a8a11ff4a5e7cf543d3176f991ba1b }, derivation_path: 1, wildcard: Unhardened }))), network: Some(Signet), local_chain: ChangeSet { blocks: {0: Some(00000008819873e925422c1ff0f99f7cc9bbb232af63a077a480a3633bee1ef6)} }, tx_graph: ChangeSet { txs: {}, txouts: {}, anchors: {}, last_seen: {}, last_evicted: {}, first_seen: {} }, indexer: ChangeSet { last_revealed: {}, spk_cache: {} } })
note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
```


