### PR TITLE
remove withdraw wallet balance check

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
 target/
+mccv-vault.sqlite
 mccv-vault.sqlite-*
+mccv-wallet.sqlite
 mccv-wallet.sqlite-*

--- a/src/main.rs
+++ b/src/main.rs
@@ -1042,9 +1042,9 @@ fn main() {
 
             assert_eq!(change, Amount::ZERO, "Invalid withdrawal amount");
 
-            let wallet_balance = vault.wallet.balance();
+            let vault_balance = vault.vault.confirmed_balance(None);
 
-            assert!(wallet_balance.confirmed >= withdrawal_args.amount);
+            assert!(vault_balance >= withdrawal_args.amount);
 
             let mut withdrawal = vault.vault.create_withdrawal(&secp, withdrawal_amount)
                 .expect("create withdrawal");


### PR DESCRIPTION
While testing `mccv withdraw`, I hit a panic because the withdraw command checked the hot wallet balance against the requested withdrawal amount:

```bash
➜  mccv git:(move_rpc) ✗ mccv withdraw "${RPC_ARGS[@]}" 10000sat

thread 'main' (7931599) panicked at src/main.rs:1047:13:
assertion failed: wallet_balance.confirmed >= withdrawal_args.amount
note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
```

Removed the assert for now. I don't think its needed as it will fail anyway when we run `create_withdrawal` if the withdraw amount is not correct. The hot wallet is only needed later for CPFP fee funding, which is handled separately.

