### PR TITLE
cli: Save and load RPC config from the database to simplify invocation

### DIFF
--- a/data/migrations/0001-initial.sql
+++ b/data/migrations/0001-initial.sql
@@ -9,6 +9,30 @@ create table mccv_secret (
 	foreign key ( id ) references mccv_vault ( id )
 );
 
+create table mccv_rpc_config (
+	id integer primary key,
+
+	rpc_url text,
+	rpc_username text,
+	rpc_password text,
+	rpc_cookie text,
+
+	constraint rpc_user_auth
+	check (
+		case
+		-- Corresponds to bitcoincore_rpc::Auth::None
+		when rpc_cookie is null and rpc_username is null and rpc_password is null then 1
+		-- Corresponds to bitcoincore_rpc::Auth::UserPass
+		when rpc_username not null and rpc_password not null then 1
+		-- Corresponds to bitcoincore_rpc::Auth::CookieFile
+		when rpc_cookie not null then 1
+		else 0
+		end
+	),
+
+	foreign key ( id ) references mccv_vault ( id )
+);
+
 create table mccv_vault (
 	id integer primary key,
 	name text,

--- a/docs/user-guide.md
+++ b/docs/user-guide.md
@@ -12,7 +12,7 @@ The wallet is divided into two parts: the hot wallet, and the vault.
 The hot wallet is a normal BDK wallet, and can be used for sending and receiving funds.
 When the user's hot wallet balance exceeds a certain amount, they may desire to increase the security of those funds.
 They can then move those funds, in fixed sized chunks, into the vault.
-Vaulted funds may not be spent immediately, they are first withdrawn and subject to a timelock, during the timelock period they can be swept to a recovery address if the withdrawal was unauthorized.
+Vaulted funds may not be spent immediately; they are first withdrawn and subject to a timelock, during the timelock period they can be swept to a recovery address if the withdrawal was unauthorized.
 
 # Overview
 
@@ -77,18 +77,10 @@ For simplicity, I'm just using `rpcuser` and `rpcpassword` for these examples si
 Note also the `addnode` line, this is necessary to ensure transactions using CTV are mined, as not all of the signet network will relay them.
 
 Once you have your configuration, you need to start your bitcoin node.
-The initial release of MCCV, v0.1.0, does not support persistent configuration of `bitcoind` RPC parameters, so every invocation of `mccv` that needs access to `bitcoind` (most of them) will need to have corresponding RPC configuration parameters.
-In `bash` you can handle this pretty easily like this:
-
-```
-RPC_ARGS=(--rpc-username test --rpc-password test --rpc-url http://127.0.0.1:38332)
-```
-
-Later, you can pass them all at once to `mccv` using the bash array expansion syntax like this `mccv sync "${RPC_ARGS[@]}"`.
 
 > [!TIP]
 > MCCV does not currently synchronize automatically.
-> After receiving funds or broadcasting transactions, run `mccv sync ...` to sync to the latest blockchain state.
+> After receiving funds or broadcasting transactions, run `mccv sync` to sync to the latest blockchain state.
 
 ## Using MCCV
 
@@ -110,13 +102,17 @@ mccv generate \
     --max-deposit 4 \
     --max-withdrawal 3 \
     --max-depth 10 \
-    "${RPC_ARGS[@]}"
+    --rpc-username test \
+    --rpc-password test \
+    --rpc-url 'http://127.0.0.1:38332'
 ```
 
 This generates a test vault, named "test" that processes deposits and withdrawals in chunks of 10,000 sats with a maximum deposit size of 40,000 sats, and a maximum withdrawal size of 30,000 sats.
 Withdrawing 10,000 sats incurs a delay of 3 blocks, 20,000 sats incurs a delay of 6 blocks, and 30,000 sats incurs a delay of 9 blocks.
 This vault permits up to 10 deposits and withdrawals before control reverts permanently to the cold recovery key.
-The `"${RPC_ARGS[@]}"` syntax is a bash array expansion to avoid retyping the RPC arguments.
+The `--rpc-*` options define how to connect to `bitcoind`.
+They will be persisted into the vault database in plain text and used for future `mccv` unless overridden on the command line.
+The persisted configuration can be changed later using `mccv configure-rpc ...`.
 For a detailed explanation of these parameters and how they affect security and performance, see the "`generate` Subcommand Arguments" section below.
 
 #### Backup and Restore
@@ -137,7 +133,7 @@ To create a receiving address, issue the command
 mccv receive
 ```
 
-Once funds have been sent to the vault, `mccv sync ...` must be issued to update the vault and hot wallet state.
+Once funds have been sent to the vault, `mccv sync` must be issued to update the vault and hot wallet state.
 
 The received balance can be checked with the command
 
@@ -162,13 +158,13 @@ In this example, no funds have been vaulted *yet*.
 Once the hot wallet contains more than a vault increment, funds can (and probably should) be moved into the vault.
 
 ```
-mccv deposit "${RPC_ARGS[@]}" 10000sat
+mccv deposit 10000sat
 ```
 
 After syncing, the vault balance should update.
 
 ```
-mccv sync "${RPC_ARGS[@]}"
+mccv sync
 ```
 
 Now `mccv balance` should display an output like this:
@@ -188,7 +184,7 @@ Withdrawing funds into the hot wallet is presently a two step process.
 The first step is to initiate the withdrawal using a command like the following:
 
 ```
-mccv withdraw "${RPC_ARGS[@]}" 10000sat
+mccv withdraw 10000sat
 ```
 
 After the withdrawal has been included in a block, and the vault is synced, the balance should be updated accordingly.
@@ -227,15 +223,15 @@ At any point until it is spent, the withdrawal and the entire vault can be swept
 The command to sweep to recovery is
 
 ```
-mccv recover "${RPC_ARGS[@]}"
+mccv recover
 ```
 
 This will sweep an open withdrawal UTXO as well as the vault UTXO to the recovery address.
 
-To spend these funds instead, they must first be moved into the hot wallet (see note above. this is a transient UX wart)
+To spend these funds instead, they must first be moved into the hot wallet (see note above; this is a transient UX wart)
 
 ```
-mccv sweep-to-hot "${RPC_ARGS[@]}"
+mccv sweep-to-hot
 ```
 
 After the sweep completes, the funds will be available in the hot wallet.
@@ -250,7 +246,7 @@ After the sweep completes, the funds will be available in the hot wallet.
 At this point the funds can be spent from the hot wallet.
 
 ```
-mccv send "${RPC_ARGS[@]}" tb1p0dvncdux9r4wqdetetng0xe830r6wum06legmk29ek5l43497epse2u5vz 10000sat
+mccv send tb1p0dvncdux9r4wqdetetng0xe830r6wum06legmk29ek5l43497epse2u5vz 10000sat
 ```
 
 # MCCV Command Reference
@@ -281,7 +277,9 @@ mccv generate \
     --max-deposit 4 \
     --max-withdrawal 3 \
     --max-depth 10 \
-    "${RPC_ARGS[@]}"
+    --rpc-username test \
+    --rpc-password test \
+    --rpc-url 'http://127.0.0.1:38332'
 ```
 
 The command line options are as follows
@@ -309,14 +307,22 @@ Doubling `max-deposit + max-withdrawal` doubles the time it takes to generate yo
 Persistent caching will greatly help here but it's not yet implemented.
 * `--max-depth` - This is the maximum number of vault operations (deposit or withdraw) you can perform.
 After the operations are exhausted, the vault will only be spendable by the cold key.
-* `"${RPC_ARGS[@]}"` - Your RPC arguments as described earlier, conveniently bundled together.
+* `--rpc-username` - Use this username to connect to `bitcoind`.
+* `--rpc-password` - Use this password to connect to `bitcoind`.
+  Note that this will be persisted in plain text in the `mccv-vault.sqlite`.
+  All of the stored RPC configuration can be updated later using `mccv configure-rpc ...`.
+  Using `--rpc-cookie` is generally preferable, and can be used instead of username and password, avoiding storing a password in the vault database.
+* `--rpc-url` - Connect to `bitcoind` at this URL.
+* `--rpc-cookie` - Use cookie-based authentication with `bitcoind` instead of username and password.
+  This avoids storing an RPC password in the vault database and is generally the preferred authentication method.
+  See `bitcoind` configuration for using cookie authentication.
 
 # Known Issues
 
 These are warts that should be removed but weren't deemed blockers to demonstrating the core concepts of this vault.
 
 ## Withdrawal Requires an Extra Sweep Step
-As stated above, the CLI currently makes vault spends a 3 step process: withdrawal, sweep, spend, instead of a 2 step process: withdraw, spend.
+As stated above, the CLI currently makes vault spends a three-step process: withdrawal, sweep, spend, instead of a 2 step process: withdraw, spend.
 This is wasteful on-chain and bad UX.
 The protocol already supports the two step process, but the code that spends the withdrawal UTXOs needs to be more flexible.
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -4,7 +4,7 @@ compile_error!("Vault CLI requires a blockchain interface, enable the `bitcoind`
 #[cfg(feature = "bitcoind")]
 use bdk_bitcoind_rpc::Emitter;
 #[cfg(feature = "bitcoind")]
-use bdk_bitcoind_rpc::bitcoincore_rpc::{Client, RpcApi};
+use bdk_bitcoind_rpc::bitcoincore_rpc::{Auth, Client, RpcApi};
 #[cfg(feature = "bitcoind")]
 use bdk_bitcoind_rpc::bitcoincore_rpc::json::GetChainTipsResultStatus;
 
@@ -105,14 +105,16 @@ enum AuthArgError {
     Invalid,
 }
 
-impl TryFrom<RpcAuthArg> for bdk_bitcoind_rpc::bitcoincore_rpc::Auth {
+impl TryFrom<&RpcAuthArg> for Option<Auth> {
     type Error = AuthArgError;
 
-    fn try_from(auth: RpcAuthArg) -> Result<Self, Self::Error> {
-        match (auth.username, auth.password, auth.cookie_path) {
-            (_, _, Some(cookie_path)) => Ok(Self::CookieFile(cookie_path)),
-            (Some(username), Some(password), _) => Ok(Self::UserPass(username, password)),
-            (None, None, None) => Ok(Self::None),
+    fn try_from(auth: &RpcAuthArg) -> Result<Self, Self::Error> {
+        match (&auth.username, &auth.password, &auth.cookie_path) {
+            (_, _, Some(cookie_path)) =>
+                Ok(Some(Auth::CookieFile(cookie_path.clone()))),
+            (Some(username), Some(password), _) =>
+                Ok(Some(Auth::UserPass(username.clone(), password.clone()))),
+            (None, None, None) => Ok(None),
             _ => Err(AuthArgError::Invalid),
         }
     }
@@ -123,19 +125,7 @@ struct RpcConf {
     #[command(flatten)]
     rpc_auth: RpcAuthArg,
     #[arg(short = 'U', long = "rpc-url")]
-    rpc_url: String,
-}
-
-impl RpcConf {
-    fn open(&self) -> Client {
-        Client::new(
-            self.rpc_url.as_ref(),
-            self.rpc_auth.clone()
-                .try_into()
-                .expect("valid auth settings")
-        )
-        .expect("valid RPC settings")
-    }
+    rpc_url: Option<String>,
 }
 
 #[derive(Clone, Args)]
@@ -228,6 +218,13 @@ struct ModifyArg {
 #[derive(Clone, Subcommand)]
 enum Command {
     Generate(GenerateArg),
+    ConfigureRpc {
+        #[arg(short, long = "vault-name", help = "Human readable identifier string")]
+        name: Option<String>,
+
+        #[command(flatten)]
+        rpc_conf: RpcConf,
+    },
     List,
     Balance {
         #[arg(short, long = "vault-name", help = "Human readable identifier string")]
@@ -438,6 +435,56 @@ impl VaultSystem {
             vault,
             vault_changelog,
         }
+    }
+
+    fn rpc_parameters(&mut self, rpc_conf: &RpcConf) -> Option<(String, Auth)> {
+        let cli_rpc_auth = Option::<Auth>::try_from(&rpc_conf.rpc_auth)
+            .expect("invalid RPC arguments");
+
+        let stored_conf = self.storage.vault_storage.load_rpc_conf(self.vault_changelog.id())
+            .expect("load rpc conf");
+
+        let rpc_url = match (&rpc_conf.rpc_url, &stored_conf) {
+            (Some(cli_rpc_url), _) => cli_rpc_url.clone(),
+            (None, Some((stored_rpc_url, _))) => stored_rpc_url.clone(),
+            (None, None) => {
+                panic!("No RPC config provided!");
+            }
+        };
+
+        let rpc_auth = match (cli_rpc_auth, stored_conf) {
+            (Some(cli_rpc_auth), _) => cli_rpc_auth,
+            (None, Some((_, stored_auth))) => stored_auth,
+            (None, None) => Auth::None,
+        };
+
+        Some(
+            (
+                rpc_url,
+                rpc_auth,
+            )
+        )
+    }
+
+    fn open_rpc(&mut self, rpc_conf: &RpcConf) -> Client {
+        let (rpc_url, rpc_auth) = self.rpc_parameters(rpc_conf)
+            .expect("RPC parameters");
+
+        Client::new(
+                rpc_url.as_ref(),
+                rpc_auth,
+            )
+            .expect("open RPC")
+    }
+
+    fn store_rpc_conf(&mut self, rpc_url: &str, rpc_auth: &Auth) {
+        self.storage.vault_storage
+            .store_rpc_conf(
+                self.vault_changelog.id(),
+                rpc_url,
+                rpc_auth,
+            )
+            .expect("store rpc config");
     }
 
     fn store(&mut self) {
@@ -664,7 +711,20 @@ fn main() {
 
     match args.command {
         Command::Generate(ref generate_arg) => {
-            let rpc_client = generate_arg.rpc_conf.open();
+            let rpc_auth = Option::<Auth>::try_from(&generate_arg.rpc_conf.rpc_auth)
+                .expect("valid RPC arguments")
+                .unwrap_or(Auth::None);
+
+            let rpc_url = generate_arg.rpc_conf.rpc_url
+                        .clone()
+                        .expect("rpc URL");
+
+            let rpc_client = Client::new(
+                    rpc_url.as_ref(),
+                    rpc_auth.clone(),
+                )
+                .expect("open rpc");
+
             let blockchain_info = rpc_client.get_blockchain_info()
                 .expect("RPC success");
             assert!(
@@ -746,7 +806,20 @@ fn main() {
 
             vault.store_vault();
 
+            vault.store_rpc_conf(rpc_url.as_ref(), &rpc_auth);
+
             println!("Saved!");
+        }
+        Command::ConfigureRpc { ref name, ref rpc_conf } => {
+            let storage = args.open_storage();
+
+            let mut vault = VaultSystem::load(&secp, storage, name.as_deref());
+
+            let (rpc_url, rpc_auth) =
+                vault.rpc_parameters(&rpc_conf)
+                    .expect("fix");
+
+            vault.store_rpc_conf(rpc_url.as_ref(), &rpc_auth);
         }
         Command::List => {
             let mut vault_storage = SqliteStorage::from_connection(
@@ -766,6 +839,7 @@ fn main() {
             let storage = args.open_storage();
 
             let vault = VaultSystem::load(&secp, storage, name.as_deref());
+
             let balance = vault.wallet.balance();
 
             let current_height = vault.vault.height()
@@ -813,8 +887,7 @@ fn main() {
             let storage = args.open_storage();
 
             let mut vault = VaultSystem::load(&secp, storage, name.as_deref());
-
-            let rpc_client = rpc_conf.open();
+            let rpc_client = vault.open_rpc(rpc_conf);
 
             let context = vault.vault.context(&secp);
 
@@ -825,9 +898,9 @@ fn main() {
         }
         Command::SweepToHot { ref name, ref fee_rate, ref rpc_conf } => {
             let storage = args.open_storage();
-            let rpc_client = rpc_conf.open();
 
             let mut vault = VaultSystem::load(&secp, storage, name.as_deref());
+            let rpc_client = vault.open_rpc(rpc_conf);
 
             let current_height = vault.vault.height()
                 .expect("must have synced at least one block");
@@ -865,12 +938,12 @@ fn main() {
             }
 
             vault.store();
-        },
+        }
         Command::Recover { ref name, ref fee_rate, ref rpc_conf } => {
             let storage = args.open_storage();
-            let rpc_client = rpc_conf.open();
 
             let mut vault = VaultSystem::load(&secp, storage, name.as_deref());
+            let rpc_client = vault.open_rpc(rpc_conf);
 
             let mut recovery = vault.vault.create_recovery(&secp)
                 .expect("create recovery");
@@ -906,16 +979,15 @@ fn main() {
             vault.store();
         }
         Command::Send { ref name, ref address, ref amount, ref rpc_conf, ref fee_rate, sweep } => {
-            let rpc_client = rpc_conf.open();
-
             let storage = args.open_storage();
 
-            let fee_rate = fee_rate.fee_rate(&rpc_client);
-
             let mut vault = VaultSystem::load(&secp, storage, name.as_deref());
+            let rpc_client = vault.open_rpc(rpc_conf);
 
             let address = address.clone().require_network(args.network)
                 .expect("address for expected network");
+
+            let fee_rate = fee_rate.fee_rate(&rpc_client);
 
             let tx = if sweep {
                 let mut builder = vault.wallet.build_tx();
@@ -970,13 +1042,10 @@ fn main() {
             println!("Address: {}", address.to_string());
         }
         Command::Deposit(ref deposit_args) => {
-            let rpc_client = deposit_args.rpc_conf.open();
-
-            let fee_rate = deposit_args.fee_rate.fee_rate(&rpc_client);
-
             let storage = args.open_storage();
 
             let mut vault = VaultSystem::load(&secp, storage, deposit_args.name.as_deref());
+            let rpc_client = vault.open_rpc(&deposit_args.rpc_conf);
 
             let (deposit_amount, change) = vault.vault.to_vault_amount(deposit_args.amount)
                 .expect("invalid deposit amount");
@@ -989,6 +1058,8 @@ fn main() {
 
             let mut deposit = vault.vault.create_deposit(&secp, deposit_amount)
                 .expect("create deposit");
+
+            let fee_rate = deposit_args.fee_rate.fee_rate(&rpc_client);
 
             let mut deposit_shape_psbt = vault
                 .wallet
@@ -1029,13 +1100,10 @@ fn main() {
             // TODO: Persist unconfirmed transactions for rebroadcast
         }
         Command::Withdraw(ref withdrawal_args) => {
-            let rpc_client = withdrawal_args.rpc_conf.open();
-
-            let fee_rate = withdrawal_args.fee_rate.fee_rate(&rpc_client);
-
             let storage = args.open_storage();
 
             let mut vault = VaultSystem::load(&secp, storage, withdrawal_args.name.as_deref());
+            let rpc_client = vault.open_rpc(&withdrawal_args.rpc_conf);
 
             let (withdrawal_amount, change) = vault.vault.to_vault_amount(withdrawal_args.amount)
                 .expect("invalid withdrawal amount");
@@ -1048,6 +1116,8 @@ fn main() {
 
             let mut withdrawal = vault.vault.create_withdrawal(&secp, withdrawal_amount)
                 .expect("create withdrawal");
+
+            let fee_rate = withdrawal_args.fee_rate.fee_rate(&rpc_client);
 
             let mut withdrawal_cpfp_psbt = vault.wallet.create_cpfp(&secp, &withdrawal, fee_rate)
                 .expect("can cpfp");

--- a/src/vault_storage.rs
+++ b/src/vault_storage.rs
@@ -1,3 +1,6 @@
+#[cfg(feature = "bitcoind")]
+use bdk_bitcoind_rpc::bitcoincore_rpc;
+
 use bitcoin::{BlockHash, Transaction, Txid};
 use bitcoin::bip32::{Xpub, Fingerprint, Xpriv, DerivationPath};
 use bitcoin::consensus::{Encodable, Decodable};
@@ -14,6 +17,8 @@ use rusqlite::{
 
 use std::collections::{hash_map, HashMap, HashSet};
 use std::ops::{Deref, DerefMut};
+#[cfg(feature = "bitcoind")]
+use std::path::PathBuf;
 
 use crate::chain::{
     AddBlockError, AddTransactionSuccess, AddTransactionError,
@@ -196,6 +201,121 @@ impl SqliteStorage {
         .optional()?;
 
         Ok(secrets)
+    }
+
+    #[cfg(feature = "bitcoind")]
+    pub fn store_rpc_conf(&mut self, id: VaultId, rpc_url: &str, auth: &bitcoincore_rpc::Auth) -> Result<(), StoreError> {
+        let transaction = self.sqlite.transaction()?;
+
+        let (rpc_username, rpc_password, rpc_cookie) = match auth {
+            bitcoincore_rpc::Auth::None => (None, None, None),
+            bitcoincore_rpc::Auth::UserPass(username, password) => (
+                Some(username.as_str()),
+                Some(password.as_str()),
+                None,
+            ),
+            bitcoincore_rpc::Auth::CookieFile(cookie_path) => (
+                None,
+                None,
+                Some(
+                    cookie_path.to_str()
+                        // FIXME: really abusing this error variant...
+                        // TODO: Make a new error type for this method
+                        .ok_or(StoreError::InvalidState)?
+                ),
+            ),
+        };
+
+        transaction.execute(r#"
+            insert
+            into mccv_rpc_config (
+                id,
+                rpc_url,
+                rpc_username,
+                rpc_password,
+                rpc_cookie
+            )
+            values ( ?, ?, ?, ?, ? )
+            on conflict ( id )
+                do update
+                    set
+                        rpc_url = excluded.rpc_url,
+                        rpc_username = excluded.rpc_username,
+                        rpc_password = excluded.rpc_password,
+                        rpc_cookie = excluded.rpc_cookie
+            "#,
+            params![
+                id,
+
+                rpc_url,
+                rpc_username,
+                rpc_password,
+                rpc_cookie,
+            ],
+        )?;
+
+        transaction.commit()?;
+
+        Ok(())
+    }
+
+    #[cfg(feature = "bitcoind")]
+    pub fn load_rpc_conf(&mut self, id: VaultId) -> Result<Option<(String, bitcoincore_rpc::Auth)>, LoadError> {
+        let transaction = self.sqlite.transaction()?;
+
+        let row =
+            transaction.query_row(r#"
+                    select
+                        rpc_url,
+                        rpc_username,
+                        rpc_password,
+                        rpc_cookie
+                    from mccv_rpc_config
+                    where
+                        id = ?
+                "#,
+                params![ id ],
+                |row| {
+                    let rpc_url: String = row.get(0)?;
+                    let rpc_username: Option<String> = row.get(1)?;
+                    let rpc_password: Option<String> = row.get(2)?;
+                    let cookie_path: Option<PathBuf> = row
+                        .get_ref(3)?
+                        .as_str_or_null()?
+                        .map(|cookie_path| PathBuf::from_str(cookie_path))
+                        .transpose()
+                        .map_err(|e| rusqlite::Error::FromSqlConversionFailure(
+                                3,
+                                rusqlite::types::Type::Text,
+                                Box::new(e),
+                            )
+                        )?;
+
+                    Ok((rpc_url, rpc_username, rpc_password, cookie_path))
+                }
+            )
+            .optional()?;
+
+        if let Some((rpc_url, rpc_username, rpc_password, cookie_path)) = row {
+            let auth = match (rpc_username, rpc_password, cookie_path) {
+                (None, None, None) => bitcoincore_rpc::Auth::None,
+                (Some(rpc_username), Some(rpc_password), None) =>
+                    bitcoincore_rpc::Auth::UserPass(
+                        rpc_username,
+                        rpc_password,
+                    ),
+                (None, None, Some(cookie_path)) =>
+                    bitcoincore_rpc::Auth::CookieFile(cookie_path),
+                _ => {
+                    // FIXME: Abusing this error variant quite a bit too
+                    return Err(LoadError::InvalidState);
+                }
+            };
+
+            Ok(Some((rpc_url, auth)))
+        } else {
+            Ok(None)
+        }
     }
 }
 


### PR DESCRIPTION
It's annoying to provide the RPC args every invocation.

- Use RPC config from database unless overridden on the command line
- Add `configure-rpc` subcommand to modify stored configuration

Fixes #22 