### PR TITLE
Rewrite protocol document and add proper diagrams

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,22 @@
+TXVIZ ?= txviz
+
+# XXX: Must keep STYLESHEETS in sync with STYLE_FLAGS manually
+STYLESHEETS=docs/diagrams/style.css
+STYLE_FLAGS=\
+ --css docs/diagrams/style.css\
+ --background-color \\\#FFFFFF
+
+DIAGRAM_SOURCES=\
+	docs/diagrams/overview.json \
+	docs/diagrams/deposit.json \
+	docs/diagrams/withdrawal.json \
+
+DIAGRAMS=$(DIAGRAM_SOURCES:.json=.svg)
+
+%.svg: %.json $(STYLESHEETS)
+	$(TXVIZ) $(STYLE_FLAGS) $< -o $@
+
+diagrams: $(DIAGRAMS)
+all: diagrams
+
+.phony: all diagrams

--- a/docs/diagrams/deposit.json
+++ b/docs/diagrams/deposit.json
@@ -1,0 +1,169 @@
+{
+  "transactions": [
+    {
+	  "title": "Deposit Shape 1",
+      "id": "deposit_shape_1",
+      "status": "candidate",
+      "outputs": [
+		  {
+			  "title": "Deposit Output",
+			  "amount_sat": 10123
+		  }
+	  ]
+    },
+    {
+	  "title": "Deposit Shape 2",
+      "id": "deposit_shape_2",
+      "status": "candidate",
+      "outputs": [
+		  {
+			  "title": "Deposit Output",
+			  "amount_sat": 20123
+		  }
+	  ]
+    },
+    {
+      "id": "deposit",
+	  "title": "Initial Deposit",
+	  "description": "",
+      "outputs": [
+		  {
+			  "title": "Vault Output",
+			  "amount_sat": 100000
+		  }
+	  ]
+    },
+    {
+	  "title": "Withdraw 1",
+      "id": "withdrawal_1",
+      "status": "candidate",
+      "inputs": [
+		  {
+			  "spends": "deposit:0",
+			  "satisfaction": {
+				  "description": "and(pk(hot), ctv(\"Withdraw 1\"))"
+			  }
+		  }
+	  ],
+      "outputs": [
+		  {
+			  "title": "Vault Output",
+			  "amount_sat": 90000
+		  },
+		  {
+			  "title": "Withdrawal Output",
+			  "amount_sat": 10000
+		  },
+		  {
+			  "title": "Anchor",
+			  "amount_sat": 0
+		  }
+	  ]
+    },
+    {
+	  "title": "Withdraw 2",
+      "id": "withdrawal_2",
+      "status": "candidate",
+      "inputs": [
+		  {
+			  "spends": "deposit:0",
+			  "satisfaction": {
+				  "description": "and(pk(hot), ctv(\"Withdraw 2\"))"
+			  }
+		  }
+	  ],
+      "outputs": [
+		  {
+			  "title": "Vault Output",
+			  "amount_sat": 80000
+		  },
+		  {
+			  "title": "Withdrawal Output",
+			  "amount_sat": 20000
+		  },
+		  {
+			  "title": "Anchor",
+			  "amount_sat": 0
+		  }
+	  ]
+    },
+    {
+	  "title": "Deposit 1",
+      "id": "deposit_1",
+      "status": "candidate",
+      "inputs": [
+		  {
+			  "spends": "deposit:0",
+			  "satisfaction": {
+				  "description": "and(pk(hot), ctv(\"Deposit 1\"))"
+			  }
+		  },
+		  {
+			  "title": "Deposit Funds",
+			  "spends": "deposit_shape_1:0",
+			  "amount_sat": 10000,
+			  "satisfaction": {
+				  "description": "and(pk(hot), ctv(\"Deposit 1\"))"
+			  }
+		  }
+	  ],
+      "outputs": [
+		  {
+			  "title": "Vault Output",
+			  "amount_sat": 110000
+		  }
+	  ]
+    },
+    {
+	  "title": "Deposit 2",
+      "id": "deposit_2",
+      "status": "candidate",
+      "inputs": [
+		  {
+			  "spends": "deposit:0",
+			  "satisfaction": {
+				  "description": "and(pk(hot), ctv(\"Deposit 2\"))"
+			  }
+		  },
+		  {
+			  "title": "Deposit Funds",
+			  "spends": "deposit_shape_2:0",
+			  "amount_sat": 20000,
+			  "satisfaction": {
+				  "description": "and(pk(hot), ctv(\"Deposit 2\"))"
+			  }
+		  }
+	  ],
+      "outputs": [
+		  {
+			  "title": "Vault Output",
+			  "amount_sat": 120000
+		  }
+	  ]
+    },
+    {
+	  "title": "Recovery",
+      "id": "recovery",
+      "status": "candidate",
+      "inputs": [
+		  {
+			  "spends": "deposit:0",
+			  "satisfaction": {
+				  "description": "and(pk(hot), ctv(\"Recovery\"))"
+			  }
+		  }
+	  ],
+      "outputs": [
+		  {
+			  "title": "Recovery Output",
+			  "description": "Only spendable by cold key",
+			  "amount_sat": 100000
+		  },
+		  {
+			  "title": "Anchor",
+			  "amount_sat": 0
+		  }
+	  ]
+    }
+  ]
+}

--- a/docs/diagrams/deposit.svg
+++ b/docs/diagrams/deposit.svg
@@ -1,0 +1,154 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg xmlns="http://www.w3.org/2000/svg" version="1.1" width="1444" height="776">
+  <metadata>txviz (docs/diagrams/deposit.json)</metadata>
+  <style>svg {
+	font-family: sans-serif;
+}
+
+.title {
+	font-weight: 800;
+}
+
+.transaction rect {
+	rx: 6px;
+	ry: 6px;
+	stroke-width: 2px;
+}
+
+.spend {
+	stroke-width: 2px;
+}
+
+.spend.candidate {
+	stroke: grey;
+	stroke-dasharray: 8px, 8px;
+}
+</style>
+  <rect class="diagram-background" x="0" y="0" width="1444" height="776" fill="#FFFFFF"/>
+  <g class="spend-links" fill="none" stroke="black" stroke-width="1">
+    <path class="spend-link spend" d="M 404 720 C 444.8 720, 499.2 382, 540 382"/>
+    <path class="spend-link spend" d="M 796 382 C 836.8 382, 891.2 44, 932 44"/>
+    <path class="spend-link spend" d="M 412 44 C 451.6 44, 504.4 62, 544 62"/>
+    <path class="spend-link spend" d="M 800 62 C 839.6 62, 892.4 80, 932 80"/>
+    <path class="spend-link spend" d="M 404 720 C 444.8 720, 499.2 440, 540 440"/>
+    <path class="spend-link spend" d="M 796 440 C 836.8 440, 891.2 160, 932 160"/>
+    <path class="spend-link spend" d="M 412 124 C 451.6 124, 504.4 160, 544 160"/>
+    <path class="spend-link spend" d="M 800 160 C 839.6 160, 892.4 196, 932 196"/>
+    <path class="spend-link spend" d="M 404 720 C 443.6 720, 496.4 498, 536 498"/>
+    <path class="spend-link spend" d="M 800 498 C 839.6 498, 892.4 276, 932 276"/>
+    <path class="spend-link spend" d="M 404 720 C 443.6 720, 496.4 574, 536 574"/>
+    <path class="spend-link spend" d="M 800 574 C 839.6 574, 892.4 428, 932 428"/>
+    <path class="spend-link spend" d="M 404 720 C 437.6 720, 482.4 650, 516 650"/>
+    <path class="spend-link spend" d="M 820 650 C 853.6 650, 898.4 580, 932 580"/>
+  </g>
+  <g class="spend-descriptions">
+    <g class="spend-description"><rect x="540" y="368" width="256" height="28" fill="white" stroke="black" stroke-width="1"/><text x="668" y="387" text-anchor="middle" fill="black">and(pk(hot), ctv("Deposit 1"))</text></g>
+    <g class="spend-description"><rect x="544" y="48" width="256" height="28" fill="white" stroke="black" stroke-width="1"/><text x="672" y="67" text-anchor="middle" fill="black">and(pk(hot), ctv("Deposit 1"))</text></g>
+    <g class="spend-description"><rect x="540" y="426" width="256" height="28" fill="white" stroke="black" stroke-width="1"/><text x="668" y="445" text-anchor="middle" fill="black">and(pk(hot), ctv("Deposit 2"))</text></g>
+    <g class="spend-description"><rect x="544" y="146" width="256" height="28" fill="white" stroke="black" stroke-width="1"/><text x="672" y="165" text-anchor="middle" fill="black">and(pk(hot), ctv("Deposit 2"))</text></g>
+    <g class="spend-description"><rect x="536" y="484" width="264" height="28" fill="white" stroke="black" stroke-width="1"/><text x="668" y="503" text-anchor="middle" fill="black">and(pk(hot), ctv("Withdraw 1"))</text></g>
+    <g class="spend-description"><rect x="536" y="560" width="264" height="28" fill="white" stroke="black" stroke-width="1"/><text x="668" y="579" text-anchor="middle" fill="black">and(pk(hot), ctv("Withdraw 2"))</text></g>
+    <g class="spend-description"><rect x="516" y="636" width="304" height="28" fill="white" stroke="black" stroke-width="1"/><text x="668" y="655" text-anchor="middle" fill="black">and(pk(hot), ctv("Recovery Output"))</text></g>
+  </g>
+  <g class="tx transaction" id="tx-deposit_shape_1">
+    <g class="tx-title"><text class="title" x="20" y="14" fill="black">Deposit Shape 1</text></g>
+    <g class="tx-body">
+      <rect class="tx-box" x="20" y="20" width="408" height="48" fill="none" stroke="black" stroke-width="1"/>
+      <g class="tx-inputs">
+      </g>
+      <g class="tx-outputs">
+        <g class="output" data-title="Deposit Output"><rect x="196" y="30" width="216" height="28" fill="none" stroke="black" stroke-width="1"/><text x="204" y="49" text-anchor="start" fill="black">Deposit Output</text><text class="amount" x="404" y="49" text-anchor="end" fill="black">10123 sat</text></g>
+      </g>
+    </g>
+  </g>
+  <g class="tx transaction" id="tx-deposit_shape_2">
+    <g class="tx-title"><text class="title" x="20" y="94" fill="black">Deposit Shape 2</text></g>
+    <g class="tx-body">
+      <rect class="tx-box" x="20" y="100" width="408" height="48" fill="none" stroke="black" stroke-width="1"/>
+      <g class="tx-inputs">
+      </g>
+      <g class="tx-outputs">
+        <g class="output" data-title="Deposit Output"><rect x="196" y="110" width="216" height="28" fill="none" stroke="black" stroke-width="1"/><text x="204" y="129" text-anchor="start" fill="black">Deposit Output</text><text class="amount" x="404" y="129" text-anchor="end" fill="black">20123 sat</text></g>
+      </g>
+    </g>
+  </g>
+  <g class="tx transaction" id="tx-deposit">
+    <g class="tx-title"><text class="title" x="20" y="690" fill="black">Initial Deposit</text></g>
+    <g class="tx-body">
+      <rect class="tx-box" x="20" y="696" width="400" height="48" fill="none" stroke="black" stroke-width="1"/>
+      <g class="tx-inputs">
+      </g>
+      <g class="tx-outputs">
+        <g class="output" data-title="Vault Output"><rect x="196" y="706" width="208" height="28" fill="none" stroke="black" stroke-width="1"/><text x="204" y="725" text-anchor="start" fill="black">Vault Output</text><text class="amount" x="396" y="725" text-anchor="end" fill="black">100000 sat</text></g>
+      </g>
+    </g>
+  </g>
+  <g class="tx transaction" id="tx-deposit_1">
+    <g class="tx-title"><text class="title" x="916" y="14" fill="black">Deposit 1</text></g>
+    <g class="tx-body">
+      <rect class="tx-box" x="916" y="20" width="488" height="84" fill="none" stroke="black" stroke-width="1"/>
+      <g class="tx-inputs">
+        <g class="input" data-title=""><rect x="932" y="30" width="208" height="28" fill="none" stroke="black" stroke-width="1"/></g>
+        <g class="input" data-title="Deposit Funds"><rect x="932" y="66" width="208" height="28" fill="none" stroke="black" stroke-width="1"/><text x="940" y="85" text-anchor="start" fill="black">Deposit Funds</text><text class="amount" x="1132" y="85" text-anchor="end" fill="black">10000 sat</text></g>
+      </g>
+      <g class="tx-outputs">
+        <g class="output" data-title="Vault Output"><rect x="1180" y="30" width="208" height="28" fill="none" stroke="black" stroke-width="1"/><text x="1188" y="49" text-anchor="start" fill="black">Vault Output</text><text class="amount" x="1380" y="49" text-anchor="end" fill="black">110000 sat</text></g>
+      </g>
+    </g>
+  </g>
+  <g class="tx transaction" id="tx-deposit_2">
+    <g class="tx-title"><text class="title" x="916" y="130" fill="black">Deposit 2</text></g>
+    <g class="tx-body">
+      <rect class="tx-box" x="916" y="136" width="488" height="84" fill="none" stroke="black" stroke-width="1"/>
+      <g class="tx-inputs">
+        <g class="input" data-title=""><rect x="932" y="146" width="208" height="28" fill="none" stroke="black" stroke-width="1"/></g>
+        <g class="input" data-title="Deposit Funds"><rect x="932" y="182" width="208" height="28" fill="none" stroke="black" stroke-width="1"/><text x="940" y="201" text-anchor="start" fill="black">Deposit Funds</text><text class="amount" x="1132" y="201" text-anchor="end" fill="black">20000 sat</text></g>
+      </g>
+      <g class="tx-outputs">
+        <g class="output" data-title="Vault Output"><rect x="1180" y="146" width="208" height="28" fill="none" stroke="black" stroke-width="1"/><text x="1188" y="165" text-anchor="start" fill="black">Vault Output</text><text class="amount" x="1380" y="165" text-anchor="end" fill="black">120000 sat</text></g>
+      </g>
+    </g>
+  </g>
+  <g class="tx transaction" id="tx-withdrawal_1">
+    <g class="tx-title"><text class="title" x="916" y="246" fill="black">Withdraw 1</text></g>
+    <g class="tx-body">
+      <rect class="tx-box" x="916" y="252" width="432" height="120" fill="none" stroke="black" stroke-width="1"/>
+      <g class="tx-inputs">
+        <g class="input" data-title=""><rect x="932" y="262" width="120" height="28" fill="none" stroke="black" stroke-width="1"/></g>
+      </g>
+      <g class="tx-outputs">
+        <g class="output" data-title="Vault Output"><rect x="1092" y="262" width="240" height="28" fill="none" stroke="black" stroke-width="1"/><text x="1100" y="281" text-anchor="start" fill="black">Vault Output</text><text class="amount" x="1324" y="281" text-anchor="end" fill="black">90000 sat</text></g>
+        <g class="output" data-title="Withdrawal Output"><rect x="1092" y="298" width="240" height="28" fill="none" stroke="black" stroke-width="1"/><text x="1100" y="317" text-anchor="start" fill="black">Withdrawal Output</text><text class="amount" x="1324" y="317" text-anchor="end" fill="black">10000 sat</text></g>
+        <g class="output" data-title="Anchor"><rect x="1092" y="334" width="240" height="28" fill="none" stroke="black" stroke-width="1"/><text x="1100" y="353" text-anchor="start" fill="black">Anchor</text><text class="amount" x="1324" y="353" text-anchor="end" fill="black">0 sat</text></g>
+      </g>
+    </g>
+  </g>
+  <g class="tx transaction" id="tx-withdrawal_2">
+    <g class="tx-title"><text class="title" x="916" y="398" fill="black">Withdraw 2</text></g>
+    <g class="tx-body">
+      <rect class="tx-box" x="916" y="404" width="432" height="120" fill="none" stroke="black" stroke-width="1"/>
+      <g class="tx-inputs">
+        <g class="input" data-title=""><rect x="932" y="414" width="120" height="28" fill="none" stroke="black" stroke-width="1"/></g>
+      </g>
+      <g class="tx-outputs">
+        <g class="output" data-title="Vault Output"><rect x="1092" y="414" width="240" height="28" fill="none" stroke="black" stroke-width="1"/><text x="1100" y="433" text-anchor="start" fill="black">Vault Output</text><text class="amount" x="1324" y="433" text-anchor="end" fill="black">80000 sat</text></g>
+        <g class="output" data-title="Withdrawal Output"><rect x="1092" y="450" width="240" height="28" fill="none" stroke="black" stroke-width="1"/><text x="1100" y="469" text-anchor="start" fill="black">Withdrawal Output</text><text class="amount" x="1324" y="469" text-anchor="end" fill="black">20000 sat</text></g>
+        <g class="output" data-title="Anchor"><rect x="1092" y="486" width="240" height="28" fill="none" stroke="black" stroke-width="1"/><text x="1100" y="505" text-anchor="start" fill="black">Anchor</text><text class="amount" x="1324" y="505" text-anchor="end" fill="black">0 sat</text></g>
+      </g>
+    </g>
+  </g>
+  <g class="tx transaction" id="tx-recovery">
+    <g class="tx-title"><text class="title" x="916" y="550" fill="black">recovery</text></g>
+    <g class="tx-body">
+      <rect class="tx-box" x="916" y="556" width="424" height="84" fill="none" stroke="black" stroke-width="1"/>
+      <g class="tx-inputs">
+        <g class="input" data-title=""><rect x="932" y="566" width="120" height="28" fill="none" stroke="black" stroke-width="1"/></g>
+      </g>
+      <g class="tx-outputs">
+        <g class="output" data-title="Recovery Output"><rect x="1092" y="566" width="232" height="28" fill="none" stroke="black" stroke-width="1"/><text x="1100" y="585" text-anchor="start" fill="black">Recovery Output</text><text class="amount" x="1316" y="585" text-anchor="end" fill="black">100000 sat</text></g>
+        <g class="output" data-title="Anchor"><rect x="1092" y="602" width="232" height="28" fill="none" stroke="black" stroke-width="1"/><text x="1100" y="621" text-anchor="start" fill="black">Anchor</text><text class="amount" x="1316" y="621" text-anchor="end" fill="black">0 sat</text></g>
+      </g>
+    </g>
+  </g>
+
+</svg>

--- a/docs/diagrams/overview.json
+++ b/docs/diagrams/overview.json
@@ -1,0 +1,444 @@
+{
+	"transactions": [
+		{
+		  "title": "Withdraw 1 (depth=1)",
+		  "id": "withdrawal_1_d1",
+		  "status": "candidate",
+		  "outputs": [
+			  {
+				  "title": "Vault Output",
+				  "amount_sat": 90000
+			  },
+			  {
+				  "title": "Withdrawal Output",
+				  "amount_sat": 10000
+			  },
+			  {
+				  "title": "Anchor",
+				  "amount_sat": 0
+			  }
+		  ]
+		},
+		{
+		  "title": "Withdraw 2 (depth=1)",
+		  "id": "withdrawal_2_d1",
+		  "status": "candidate",
+		  "outputs": [
+			  {
+				  "title": "Vault Output",
+				  "amount_sat": 80000
+			  },
+			  {
+				  "title": "Withdrawal Output",
+				  "amount_sat": 20000
+			  },
+			  {
+				  "title": "Anchor",
+				  "amount_sat": 0
+			  }
+		  ]
+		},
+		{
+		  "title": "Deposit 1 (depth=1)",
+		  "id": "deposit_1_d1",
+		  "status": "candidate",
+		  "outputs": [
+			  {
+				  "title": "Vault Output",
+				  "amount_sat": 110000
+			  }
+		  ]
+		},
+		{
+		  "title": "Deposit 2 (depth=1)",
+		  "id": "deposit_2_d1",
+		  "status": "candidate",
+		  "outputs": [
+			  {
+				  "title": "Vault Output",
+				  "amount_sat": 120000
+			  }
+		  ]
+		},
+
+		{
+		  "title": "Withdraw 1 (depth=2, last=\"Withdraw 1\")",
+		  "id": "withdrawal_1_v9_d2",
+		  "status": "candidate",
+		  "inputs": [
+			  {
+				  "spends": "withdrawal_1_d1:0",
+				  "sequence": {
+					  "height": 3
+				  }
+			  }
+		  ],
+		  "outputs": [
+			  {
+				  "title": "Vault Output",
+				  "amount_sat": 80000
+			  },
+			  {
+				  "title": "Withdrawal Output",
+				  "amount_sat": 10000
+			  },
+			  {
+				  "title": "Anchor",
+				  "amount_sat": 0
+			  }
+		  ]
+		},
+		{
+		  "title": "Withdraw 2 (depth=2, last=\"Withdraw 1\")",
+		  "id": "withdrawal_2_v9_d1",
+		  "status": "candidate",
+		  "inputs": [
+			  {
+				  "spends": "withdrawal_1_d1:0",
+				  "sequence": {
+					  "height": 3
+				  }
+			  }
+		  ],
+		  "outputs": [
+			  {
+				  "title": "Vault Output",
+				  "amount_sat": 70000
+			  },
+			  {
+				  "title": "Withdrawal Output",
+				  "amount_sat": 20000
+			  },
+			  {
+				  "title": "Anchor",
+				  "amount_sat": 0
+			  }
+		  ]
+		},
+		{
+		  "title": "Deposit 1 (depth=2, last=\"Withdraw 1\")",
+		  "id": "deposit_1_v9_d2",
+		  "status": "candidate",
+		  "inputs": [
+			  {
+				  "spends": "withdrawal_1_d1:0",
+				  "sequence": {
+					  "height": 3
+				  }
+			  },
+			  {
+				  "title": "Deposit",
+				  "amount_sat": 10123
+			  }
+		  ],
+		  "outputs": [
+			  {
+				  "title": "Vault Output",
+				  "amount_sat": 100000
+			  }
+		  ]
+		},
+		{
+		  "title": "Deposit 2 (depth=2, last=\"Withdraw 1\")",
+		  "id": "deposit_2_v9_d2",
+		  "status": "candidate",
+		  "inputs": [
+			  {
+				  "spends": "withdrawal_1_d1:0",
+				  "sequence": {
+					  "height": 3
+				  }
+			  },
+			  {
+				  "title": "Deposit",
+				  "amount_sat": 20123
+			  }
+		  ],
+		  "outputs": [
+			  {
+				  "title": "Vault Output",
+				  "amount_sat": 110000
+			  }
+		  ]
+		},
+
+		{
+		  "title": "Withdraw 1 (depth=2, last=\"Withdraw 2\")",
+		  "id": "withdrawal_1_v8_d1",
+		  "status": "candidate",
+		  "inputs": [
+			  {
+				  "spends": "withdrawal_2_d1:0",
+				  "sequence": {
+					  "height": 6
+				  }
+			  }
+		  ],
+		  "outputs": [
+			  {
+				  "title": "Vault Output",
+				  "amount_sat": 70000
+			  },
+			  {
+				  "title": "Withdrawal Output",
+				  "amount_sat": 10000
+			  },
+			  {
+				  "title": "Anchor",
+				  "amount_sat": 0
+			  }
+		  ]
+		},
+		{
+		  "title": "Withdraw 2 (depth=2, last=\"Withdraw 2\")",
+		  "id": "withdrawal_2_v8_d1",
+		  "status": "candidate",
+		  "inputs": [
+			  {
+				  "spends": "withdrawal_2_d1:0",
+				  "sequence": {
+					  "height": 6
+				  }
+			  }
+		  ],
+		  "outputs": [
+			  {
+				  "title": "Vault Output",
+				  "amount_sat": 60000
+			  },
+			  {
+				  "title": "Withdrawal Output",
+				  "amount_sat": 20000
+			  },
+			  {
+				  "title": "Anchor",
+				  "amount_sat": 0
+			  }
+		  ]
+		},
+		{
+		  "title": "Deposit 1 (depth=2, last=\"Withdraw 2\")",
+		  "id": "deposit_1_v8_d2",
+		  "status": "candidate",
+		  "inputs": [
+			  {
+				  "spends": "withdrawal_2_d1:0",
+				  "sequence": {
+					  "height": 6
+				  }
+			  },
+			  {
+				  "title": "Deposit",
+				  "amount_sat": 10123
+			  }
+		  ],
+		  "outputs": [
+			  {
+				  "title": "Vault Output",
+				  "amount_sat": 90000
+			  }
+		  ]
+		},
+		{
+		  "title": "Deposit 2 (depth=2, last=\"Withdraw 2\")",
+		  "id": "deposit_2_v8_d2",
+		  "status": "candidate",
+		  "inputs": [
+			  {
+				  "spends": "withdrawal_2_d1:0",
+				  "sequence": {
+					  "height": 6
+				  }
+			  },
+			  {
+				  "title": "Deposit",
+				  "amount_sat": 20123
+			  }
+		  ],
+		  "outputs": [
+			  {
+				  "title": "Vault Output",
+				  "amount_sat": 100000
+			  }
+		  ]
+		},
+
+		{
+		  "title": "Withdraw 1 (depth=2, last=\"Deposit 1\")",
+		  "id": "withdraw_1_v11_d2",
+		  "status": "candidate",
+		  "inputs": [
+			  {
+				  "spends": "deposit_1_d1:0"
+			  }
+		  ],
+		  "outputs": [
+			  {
+				  "title": "Vault Output",
+				  "amount_sat": 100000
+			  },
+			  {
+				  "title": "Withdrawal Output",
+				  "amount_sat": 10000
+			  },
+			  {
+				  "title": "Anchor",
+				  "amount_sat": 0
+			  }
+		  ]
+		},
+		{
+		  "title": "Withdraw 2 (depth=2, last=\"Deposit 1\")",
+		  "id": "withdrawal_2_v11_d2",
+		  "status": "candidate",
+		  "inputs": [
+			  {
+				  "spends": "deposit_1_d1:0"
+			  }
+		  ],
+		  "outputs": [
+			  {
+				  "title": "Vault Output",
+				  "amount_sat": 90000
+			  },
+			  {
+				  "title": "Withdrawal Output",
+				  "amount_sat": 20000
+			  },
+			  {
+				  "title": "Anchor",
+				  "amount_sat": 0
+			  }
+		  ]
+		},
+		{
+		  "title": "Deposit 1 (depth=2, last=\"Deposit 1\")",
+		  "id": "deposit_1_v11_d2",
+		  "status": "candidate",
+		  "inputs": [
+			  {
+				  "spends": "deposit_1_d1:0"
+			  },
+			  {
+				  "title": "Deposit",
+				  "amount_sat": 10123
+			  }
+		  ],
+		  "outputs": [
+			  {
+				  "title": "Vault Output",
+				  "amount_sat": 120000
+			  }
+		  ]
+		},
+		{
+		  "title": "Deposit 2 (depth=2, last=\"Deposit 1\")",
+		  "id": "deposit_2_v11_d2",
+		  "status": "candidate",
+		  "inputs": [
+			  {
+				  "spends": "deposit_1_d1:0"
+			  },
+			  {
+				  "title": "Deposit",
+				  "amount_sat": 20123
+			  }
+		  ],
+		  "outputs": [
+			  {
+				  "title": "Vault Output",
+				  "amount_sat": 130000
+			  }
+		  ]
+		},
+
+		{
+		  "title": "Withdraw 1 (depth=2, last=\"Deposit 2\")",
+		  "id": "withdraw_1_v12_d2",
+		  "status": "candidate",
+		  "inputs": [
+			  {
+				  "spends": "deposit_2_d1:0"
+			  }
+		  ],
+		  "outputs": [
+			  {
+				  "title": "Vault Output",
+				  "amount_sat": 110000
+			  },
+			  {
+				  "title": "Withdrawal Output",
+				  "amount_sat": 10000
+			  },
+			  {
+				  "title": "Anchor",
+				  "amount_sat": 0
+			  }
+		  ]
+		},
+		{
+		  "title": "Withdraw 2 (depth=2, last=\"Deposit 2\")",
+		  "id": "withdrawal_2_v12_d2",
+		  "status": "candidate",
+		  "inputs": [
+			  {
+				  "spends": "deposit_2_d1:0"
+			  }
+		  ],
+		  "outputs": [
+			  {
+				  "title": "Vault Output",
+				  "amount_sat": 100000
+			  },
+			  {
+				  "title": "Withdrawal Output",
+				  "amount_sat": 20000
+			  },
+			  {
+				  "title": "Anchor",
+				  "amount_sat": 0
+			  }
+		  ]
+		},
+		{
+		  "title": "Deposit 1 (depth=2, last=\"Deposit 2\")",
+		  "id": "deposit_1_v12_d2",
+		  "status": "candidate",
+		  "inputs": [
+			  {
+				  "spends": "deposit_2_d1:0"
+			  },
+			  {
+				  "title": "Deposit",
+				  "amount_sat": 10123
+			  }
+		  ],
+		  "outputs": [
+			  {
+				  "title": "Vault Output",
+				  "amount_sat": 130000
+			  }
+		  ]
+		},
+		{
+		  "title": "Deposit 2 (depth=2, last=\"Deposit 2\")",
+		  "id": "deposit_2_v12_d2",
+		  "status": "candidate",
+		  "inputs": [
+			  {
+				  "spends": "deposit_2_d1:0"
+			  },
+			  {
+				  "title": "Deposit",
+				  "amount_sat": 20123
+			  }
+		  ],
+		  "outputs": [
+			  {
+				  "title": "Vault Output",
+				  "amount_sat": 140000
+			  }
+		  ]
+		}
+	]
+}

--- a/docs/diagrams/overview.svg
+++ b/docs/diagrams/overview.svg
@@ -1,0 +1,313 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg xmlns="http://www.w3.org/2000/svg" version="1.1" width="1372" height="2164">
+  <metadata>txviz (docs/diagrams/overview.json)</metadata>
+  <style>svg {
+	font-family: sans-serif;
+}
+
+.title {
+	font-weight: 800;
+}
+
+.transaction rect {
+	rx: 6px;
+	ry: 6px;
+	stroke-width: 2px;
+}
+
+.spend {
+	stroke-width: 2px;
+}
+
+.spend.candidate {
+	stroke: grey;
+	stroke-dasharray: 8px, 8px;
+}
+</style>
+  <rect class="diagram-background" x="0" y="0" width="1372" height="2164" fill="#FFFFFF"/>
+  <g class="spend-links" fill="none" stroke="black" stroke-width="1">
+    <path class="spend-link spend" d="M 436 396 C 577.6 396, 766.4 44, 908 44"/>
+    <path class="spend-link spend" d="M 436 396 C 577.6 396, 766.4 196, 908 196"/>
+    <path class="spend-link spend" d="M 436 396 C 577.6 396, 766.4 348, 908 348"/>
+    <path class="spend-link spend" d="M 436 396 C 577.6 396, 766.4 464, 908 464"/>
+    <path class="spend-link spend" d="M 436 900 C 577.6 900, 766.4 580, 908 580"/>
+    <path class="spend-link spend" d="M 436 900 C 577.6 900, 766.4 732, 908 732"/>
+    <path class="spend-link spend" d="M 436 900 C 577.6 900, 766.4 884, 908 884"/>
+    <path class="spend-link spend" d="M 436 900 C 577.6 900, 766.4 1000, 908 1000"/>
+    <path class="spend-link spend" d="M 404 1460 C 555.2 1460, 756.8 1116, 908 1116"/>
+    <path class="spend-link spend" d="M 404 1460 C 555.2 1460, 756.8 1268, 908 1268"/>
+    <path class="spend-link spend" d="M 404 1460 C 555.2 1460, 756.8 1420, 908 1420"/>
+    <path class="spend-link spend" d="M 404 1460 C 555.2 1460, 756.8 1536, 908 1536"/>
+    <path class="spend-link spend" d="M 404 1948 C 555.2 1948, 756.8 1652, 908 1652"/>
+    <path class="spend-link spend" d="M 404 1948 C 555.2 1948, 756.8 1804, 908 1804"/>
+    <path class="spend-link spend" d="M 404 1948 C 555.2 1948, 756.8 1956, 908 1956"/>
+    <path class="spend-link spend" d="M 404 1948 C 555.2 1948, 756.8 2072, 908 2072"/>
+  </g>
+  <g class="spend-descriptions">
+  </g>
+  <g class="tx transaction" id="tx-withdrawal_1_d1">
+    <g class="tx-title"><text class="title" x="20" y="366" fill="black">Withdraw 1 (depth=1)</text></g>
+    <g class="tx-body">
+      <rect class="tx-box" x="20" y="372" width="432" height="120" fill="none" stroke="black" stroke-width="1"/>
+      <g class="tx-inputs">
+      </g>
+      <g class="tx-outputs">
+        <g class="output" data-title="Vault Output"><rect x="196" y="382" width="240" height="28" fill="none" stroke="black" stroke-width="1"/><text x="204" y="401" text-anchor="start" fill="black">Vault Output</text><text class="amount" x="428" y="401" text-anchor="end" fill="black">90000 sat</text></g>
+        <g class="output" data-title="Withdrawal Output"><rect x="196" y="418" width="240" height="28" fill="none" stroke="black" stroke-width="1"/><text x="204" y="437" text-anchor="start" fill="black">Withdrawal Output</text><text class="amount" x="428" y="437" text-anchor="end" fill="black">10000 sat</text></g>
+        <g class="output" data-title="Anchor"><rect x="196" y="454" width="240" height="28" fill="none" stroke="black" stroke-width="1"/><text x="204" y="473" text-anchor="start" fill="black">Anchor</text><text class="amount" x="428" y="473" text-anchor="end" fill="black">0 sat</text></g>
+      </g>
+    </g>
+  </g>
+  <g class="tx transaction" id="tx-withdrawal_2_d1">
+    <g class="tx-title"><text class="title" x="20" y="870" fill="black">Withdraw 2 (depth=1)</text></g>
+    <g class="tx-body">
+      <rect class="tx-box" x="20" y="876" width="432" height="120" fill="none" stroke="black" stroke-width="1"/>
+      <g class="tx-inputs">
+      </g>
+      <g class="tx-outputs">
+        <g class="output" data-title="Vault Output"><rect x="196" y="886" width="240" height="28" fill="none" stroke="black" stroke-width="1"/><text x="204" y="905" text-anchor="start" fill="black">Vault Output</text><text class="amount" x="428" y="905" text-anchor="end" fill="black">80000 sat</text></g>
+        <g class="output" data-title="Withdrawal Output"><rect x="196" y="922" width="240" height="28" fill="none" stroke="black" stroke-width="1"/><text x="204" y="941" text-anchor="start" fill="black">Withdrawal Output</text><text class="amount" x="428" y="941" text-anchor="end" fill="black">20000 sat</text></g>
+        <g class="output" data-title="Anchor"><rect x="196" y="958" width="240" height="28" fill="none" stroke="black" stroke-width="1"/><text x="204" y="977" text-anchor="start" fill="black">Anchor</text><text class="amount" x="428" y="977" text-anchor="end" fill="black">0 sat</text></g>
+      </g>
+    </g>
+  </g>
+  <g class="tx transaction" id="tx-deposit_1_d1">
+    <g class="tx-title"><text class="title" x="20" y="1430" fill="black">Deposit 1 (depth=1)</text></g>
+    <g class="tx-body">
+      <rect class="tx-box" x="20" y="1436" width="400" height="48" fill="none" stroke="black" stroke-width="1"/>
+      <g class="tx-inputs">
+      </g>
+      <g class="tx-outputs">
+        <g class="output" data-title="Vault Output"><rect x="196" y="1446" width="208" height="28" fill="none" stroke="black" stroke-width="1"/><text x="204" y="1465" text-anchor="start" fill="black">Vault Output</text><text class="amount" x="396" y="1465" text-anchor="end" fill="black">110000 sat</text></g>
+      </g>
+    </g>
+  </g>
+  <g class="tx transaction" id="tx-deposit_2_d1">
+    <g class="tx-title"><text class="title" x="20" y="1918" fill="black">Deposit 2 (depth=1)</text></g>
+    <g class="tx-body">
+      <rect class="tx-box" x="20" y="1924" width="400" height="48" fill="none" stroke="black" stroke-width="1"/>
+      <g class="tx-inputs">
+      </g>
+      <g class="tx-outputs">
+        <g class="output" data-title="Vault Output"><rect x="196" y="1934" width="208" height="28" fill="none" stroke="black" stroke-width="1"/><text x="204" y="1953" text-anchor="start" fill="black">Vault Output</text><text class="amount" x="396" y="1953" text-anchor="end" fill="black">120000 sat</text></g>
+      </g>
+    </g>
+  </g>
+  <g class="tx transaction" id="tx-withdrawal_1_v9_d2">
+    <g class="tx-title"><text class="title" x="892" y="14" fill="black">Withdraw 1 (depth=2, last="Withdraw 1")</text></g>
+    <g class="tx-body">
+      <rect class="tx-box" x="892" y="20" width="440" height="120" fill="none" stroke="black" stroke-width="1"/>
+      <g class="tx-inputs">
+        <g class="input" data-title=""><rect x="908" y="30" width="120" height="28" fill="none" stroke="black" stroke-width="1"/><text class="sequence" x="916" y="49" text-anchor="start" fill="black">after 3 blocks</text></g>
+      </g>
+      <g class="tx-outputs">
+        <g class="output" data-title="Vault Output"><rect x="1076" y="30" width="240" height="28" fill="none" stroke="black" stroke-width="1"/><text x="1084" y="49" text-anchor="start" fill="black">Vault Output</text><text class="amount" x="1308" y="49" text-anchor="end" fill="black">80000 sat</text></g>
+        <g class="output" data-title="Withdrawal Output"><rect x="1076" y="66" width="240" height="28" fill="none" stroke="black" stroke-width="1"/><text x="1084" y="85" text-anchor="start" fill="black">Withdrawal Output</text><text class="amount" x="1308" y="85" text-anchor="end" fill="black">10000 sat</text></g>
+        <g class="output" data-title="Anchor"><rect x="1076" y="102" width="240" height="28" fill="none" stroke="black" stroke-width="1"/><text x="1084" y="121" text-anchor="start" fill="black">Anchor</text><text class="amount" x="1308" y="121" text-anchor="end" fill="black">0 sat</text></g>
+      </g>
+    </g>
+  </g>
+  <g class="tx transaction" id="tx-withdrawal_2_v9_d1">
+    <g class="tx-title"><text class="title" x="892" y="166" fill="black">Withdraw 2 (depth=2, last="Withdraw 1")</text></g>
+    <g class="tx-body">
+      <rect class="tx-box" x="892" y="172" width="440" height="120" fill="none" stroke="black" stroke-width="1"/>
+      <g class="tx-inputs">
+        <g class="input" data-title=""><rect x="908" y="182" width="120" height="28" fill="none" stroke="black" stroke-width="1"/><text class="sequence" x="916" y="201" text-anchor="start" fill="black">after 3 blocks</text></g>
+      </g>
+      <g class="tx-outputs">
+        <g class="output" data-title="Vault Output"><rect x="1076" y="182" width="240" height="28" fill="none" stroke="black" stroke-width="1"/><text x="1084" y="201" text-anchor="start" fill="black">Vault Output</text><text class="amount" x="1308" y="201" text-anchor="end" fill="black">70000 sat</text></g>
+        <g class="output" data-title="Withdrawal Output"><rect x="1076" y="218" width="240" height="28" fill="none" stroke="black" stroke-width="1"/><text x="1084" y="237" text-anchor="start" fill="black">Withdrawal Output</text><text class="amount" x="1308" y="237" text-anchor="end" fill="black">20000 sat</text></g>
+        <g class="output" data-title="Anchor"><rect x="1076" y="254" width="240" height="28" fill="none" stroke="black" stroke-width="1"/><text x="1084" y="273" text-anchor="start" fill="black">Anchor</text><text class="amount" x="1308" y="273" text-anchor="end" fill="black">0 sat</text></g>
+      </g>
+    </g>
+  </g>
+  <g class="tx transaction" id="tx-deposit_1_v9_d2">
+    <g class="tx-title"><text class="title" x="892" y="318" fill="black">Deposit 1 (depth=2, last="Withdraw 1")</text></g>
+    <g class="tx-body">
+      <rect class="tx-box" x="892" y="324" width="440" height="84" fill="none" stroke="black" stroke-width="1"/>
+      <g class="tx-inputs">
+        <g class="input" data-title=""><rect x="908" y="334" width="160" height="28" fill="none" stroke="black" stroke-width="1"/><text class="sequence" x="916" y="353" text-anchor="start" fill="black">after 3 blocks</text></g>
+        <g class="input" data-title="Deposit"><rect x="908" y="370" width="160" height="28" fill="none" stroke="black" stroke-width="1"/><text x="916" y="389" text-anchor="start" fill="black">Deposit</text><text class="amount" x="1060" y="389" text-anchor="end" fill="black">10123 sat</text></g>
+      </g>
+      <g class="tx-outputs">
+        <g class="output" data-title="Vault Output"><rect x="1108" y="334" width="208" height="28" fill="none" stroke="black" stroke-width="1"/><text x="1116" y="353" text-anchor="start" fill="black">Vault Output</text><text class="amount" x="1308" y="353" text-anchor="end" fill="black">100000 sat</text></g>
+      </g>
+    </g>
+  </g>
+  <g class="tx transaction" id="tx-deposit_2_v9_d2">
+    <g class="tx-title"><text class="title" x="892" y="434" fill="black">Deposit 2 (depth=2, last="Withdraw 1")</text></g>
+    <g class="tx-body">
+      <rect class="tx-box" x="892" y="440" width="440" height="84" fill="none" stroke="black" stroke-width="1"/>
+      <g class="tx-inputs">
+        <g class="input" data-title=""><rect x="908" y="450" width="160" height="28" fill="none" stroke="black" stroke-width="1"/><text class="sequence" x="916" y="469" text-anchor="start" fill="black">after 3 blocks</text></g>
+        <g class="input" data-title="Deposit"><rect x="908" y="486" width="160" height="28" fill="none" stroke="black" stroke-width="1"/><text x="916" y="505" text-anchor="start" fill="black">Deposit</text><text class="amount" x="1060" y="505" text-anchor="end" fill="black">20123 sat</text></g>
+      </g>
+      <g class="tx-outputs">
+        <g class="output" data-title="Vault Output"><rect x="1108" y="450" width="208" height="28" fill="none" stroke="black" stroke-width="1"/><text x="1116" y="469" text-anchor="start" fill="black">Vault Output</text><text class="amount" x="1308" y="469" text-anchor="end" fill="black">110000 sat</text></g>
+      </g>
+    </g>
+  </g>
+  <g class="tx transaction" id="tx-withdrawal_1_v8_d1">
+    <g class="tx-title"><text class="title" x="892" y="550" fill="black">Withdraw 1 (depth=2, last="Withdraw 2")</text></g>
+    <g class="tx-body">
+      <rect class="tx-box" x="892" y="556" width="440" height="120" fill="none" stroke="black" stroke-width="1"/>
+      <g class="tx-inputs">
+        <g class="input" data-title=""><rect x="908" y="566" width="120" height="28" fill="none" stroke="black" stroke-width="1"/><text class="sequence" x="916" y="585" text-anchor="start" fill="black">after 6 blocks</text></g>
+      </g>
+      <g class="tx-outputs">
+        <g class="output" data-title="Vault Output"><rect x="1076" y="566" width="240" height="28" fill="none" stroke="black" stroke-width="1"/><text x="1084" y="585" text-anchor="start" fill="black">Vault Output</text><text class="amount" x="1308" y="585" text-anchor="end" fill="black">70000 sat</text></g>
+        <g class="output" data-title="Withdrawal Output"><rect x="1076" y="602" width="240" height="28" fill="none" stroke="black" stroke-width="1"/><text x="1084" y="621" text-anchor="start" fill="black">Withdrawal Output</text><text class="amount" x="1308" y="621" text-anchor="end" fill="black">10000 sat</text></g>
+        <g class="output" data-title="Anchor"><rect x="1076" y="638" width="240" height="28" fill="none" stroke="black" stroke-width="1"/><text x="1084" y="657" text-anchor="start" fill="black">Anchor</text><text class="amount" x="1308" y="657" text-anchor="end" fill="black">0 sat</text></g>
+      </g>
+    </g>
+  </g>
+  <g class="tx transaction" id="tx-withdrawal_2_v8_d1">
+    <g class="tx-title"><text class="title" x="892" y="702" fill="black">Withdraw 2 (depth=2, last="Withdraw 2")</text></g>
+    <g class="tx-body">
+      <rect class="tx-box" x="892" y="708" width="440" height="120" fill="none" stroke="black" stroke-width="1"/>
+      <g class="tx-inputs">
+        <g class="input" data-title=""><rect x="908" y="718" width="120" height="28" fill="none" stroke="black" stroke-width="1"/><text class="sequence" x="916" y="737" text-anchor="start" fill="black">after 6 blocks</text></g>
+      </g>
+      <g class="tx-outputs">
+        <g class="output" data-title="Vault Output"><rect x="1076" y="718" width="240" height="28" fill="none" stroke="black" stroke-width="1"/><text x="1084" y="737" text-anchor="start" fill="black">Vault Output</text><text class="amount" x="1308" y="737" text-anchor="end" fill="black">60000 sat</text></g>
+        <g class="output" data-title="Withdrawal Output"><rect x="1076" y="754" width="240" height="28" fill="none" stroke="black" stroke-width="1"/><text x="1084" y="773" text-anchor="start" fill="black">Withdrawal Output</text><text class="amount" x="1308" y="773" text-anchor="end" fill="black">20000 sat</text></g>
+        <g class="output" data-title="Anchor"><rect x="1076" y="790" width="240" height="28" fill="none" stroke="black" stroke-width="1"/><text x="1084" y="809" text-anchor="start" fill="black">Anchor</text><text class="amount" x="1308" y="809" text-anchor="end" fill="black">0 sat</text></g>
+      </g>
+    </g>
+  </g>
+  <g class="tx transaction" id="tx-deposit_1_v8_d2">
+    <g class="tx-title"><text class="title" x="892" y="854" fill="black">Deposit 1 (depth=2, last="Withdraw 2")</text></g>
+    <g class="tx-body">
+      <rect class="tx-box" x="892" y="860" width="432" height="84" fill="none" stroke="black" stroke-width="1"/>
+      <g class="tx-inputs">
+        <g class="input" data-title=""><rect x="908" y="870" width="160" height="28" fill="none" stroke="black" stroke-width="1"/><text class="sequence" x="916" y="889" text-anchor="start" fill="black">after 6 blocks</text></g>
+        <g class="input" data-title="Deposit"><rect x="908" y="906" width="160" height="28" fill="none" stroke="black" stroke-width="1"/><text x="916" y="925" text-anchor="start" fill="black">Deposit</text><text class="amount" x="1060" y="925" text-anchor="end" fill="black">10123 sat</text></g>
+      </g>
+      <g class="tx-outputs">
+        <g class="output" data-title="Vault Output"><rect x="1108" y="870" width="200" height="28" fill="none" stroke="black" stroke-width="1"/><text x="1116" y="889" text-anchor="start" fill="black">Vault Output</text><text class="amount" x="1300" y="889" text-anchor="end" fill="black">90000 sat</text></g>
+      </g>
+    </g>
+  </g>
+  <g class="tx transaction" id="tx-deposit_2_v8_d2">
+    <g class="tx-title"><text class="title" x="892" y="970" fill="black">Deposit 2 (depth=2, last="Withdraw 2")</text></g>
+    <g class="tx-body">
+      <rect class="tx-box" x="892" y="976" width="440" height="84" fill="none" stroke="black" stroke-width="1"/>
+      <g class="tx-inputs">
+        <g class="input" data-title=""><rect x="908" y="986" width="160" height="28" fill="none" stroke="black" stroke-width="1"/><text class="sequence" x="916" y="1005" text-anchor="start" fill="black">after 6 blocks</text></g>
+        <g class="input" data-title="Deposit"><rect x="908" y="1022" width="160" height="28" fill="none" stroke="black" stroke-width="1"/><text x="916" y="1041" text-anchor="start" fill="black">Deposit</text><text class="amount" x="1060" y="1041" text-anchor="end" fill="black">20123 sat</text></g>
+      </g>
+      <g class="tx-outputs">
+        <g class="output" data-title="Vault Output"><rect x="1108" y="986" width="208" height="28" fill="none" stroke="black" stroke-width="1"/><text x="1116" y="1005" text-anchor="start" fill="black">Vault Output</text><text class="amount" x="1308" y="1005" text-anchor="end" fill="black">100000 sat</text></g>
+      </g>
+    </g>
+  </g>
+  <g class="tx transaction" id="tx-withdraw_1_v11_d2">
+    <g class="tx-title"><text class="title" x="892" y="1086" fill="black">Withdraw 1 (depth=2, last="Deposit 1")</text></g>
+    <g class="tx-body">
+      <rect class="tx-box" x="892" y="1092" width="432" height="120" fill="none" stroke="black" stroke-width="1"/>
+      <g class="tx-inputs">
+        <g class="input" data-title=""><rect x="908" y="1102" width="120" height="28" fill="none" stroke="black" stroke-width="1"/></g>
+      </g>
+      <g class="tx-outputs">
+        <g class="output" data-title="Vault Output"><rect x="1068" y="1102" width="240" height="28" fill="none" stroke="black" stroke-width="1"/><text x="1076" y="1121" text-anchor="start" fill="black">Vault Output</text><text class="amount" x="1300" y="1121" text-anchor="end" fill="black">100000 sat</text></g>
+        <g class="output" data-title="Withdrawal Output"><rect x="1068" y="1138" width="240" height="28" fill="none" stroke="black" stroke-width="1"/><text x="1076" y="1157" text-anchor="start" fill="black">Withdrawal Output</text><text class="amount" x="1300" y="1157" text-anchor="end" fill="black">10000 sat</text></g>
+        <g class="output" data-title="Anchor"><rect x="1068" y="1174" width="240" height="28" fill="none" stroke="black" stroke-width="1"/><text x="1076" y="1193" text-anchor="start" fill="black">Anchor</text><text class="amount" x="1300" y="1193" text-anchor="end" fill="black">0 sat</text></g>
+      </g>
+    </g>
+  </g>
+  <g class="tx transaction" id="tx-withdrawal_2_v11_d2">
+    <g class="tx-title"><text class="title" x="892" y="1238" fill="black">Withdraw 2 (depth=2, last="Deposit 1")</text></g>
+    <g class="tx-body">
+      <rect class="tx-box" x="892" y="1244" width="432" height="120" fill="none" stroke="black" stroke-width="1"/>
+      <g class="tx-inputs">
+        <g class="input" data-title=""><rect x="908" y="1254" width="120" height="28" fill="none" stroke="black" stroke-width="1"/></g>
+      </g>
+      <g class="tx-outputs">
+        <g class="output" data-title="Vault Output"><rect x="1068" y="1254" width="240" height="28" fill="none" stroke="black" stroke-width="1"/><text x="1076" y="1273" text-anchor="start" fill="black">Vault Output</text><text class="amount" x="1300" y="1273" text-anchor="end" fill="black">90000 sat</text></g>
+        <g class="output" data-title="Withdrawal Output"><rect x="1068" y="1290" width="240" height="28" fill="none" stroke="black" stroke-width="1"/><text x="1076" y="1309" text-anchor="start" fill="black">Withdrawal Output</text><text class="amount" x="1300" y="1309" text-anchor="end" fill="black">20000 sat</text></g>
+        <g class="output" data-title="Anchor"><rect x="1068" y="1326" width="240" height="28" fill="none" stroke="black" stroke-width="1"/><text x="1076" y="1345" text-anchor="start" fill="black">Anchor</text><text class="amount" x="1300" y="1345" text-anchor="end" fill="black">0 sat</text></g>
+      </g>
+    </g>
+  </g>
+  <g class="tx transaction" id="tx-deposit_1_v11_d2">
+    <g class="tx-title"><text class="title" x="892" y="1390" fill="black">Deposit 1 (depth=2, last="Deposit 1")</text></g>
+    <g class="tx-body">
+      <rect class="tx-box" x="892" y="1396" width="440" height="84" fill="none" stroke="black" stroke-width="1"/>
+      <g class="tx-inputs">
+        <g class="input" data-title=""><rect x="908" y="1406" width="160" height="28" fill="none" stroke="black" stroke-width="1"/></g>
+        <g class="input" data-title="Deposit"><rect x="908" y="1442" width="160" height="28" fill="none" stroke="black" stroke-width="1"/><text x="916" y="1461" text-anchor="start" fill="black">Deposit</text><text class="amount" x="1060" y="1461" text-anchor="end" fill="black">10123 sat</text></g>
+      </g>
+      <g class="tx-outputs">
+        <g class="output" data-title="Vault Output"><rect x="1108" y="1406" width="208" height="28" fill="none" stroke="black" stroke-width="1"/><text x="1116" y="1425" text-anchor="start" fill="black">Vault Output</text><text class="amount" x="1308" y="1425" text-anchor="end" fill="black">120000 sat</text></g>
+      </g>
+    </g>
+  </g>
+  <g class="tx transaction" id="tx-deposit_2_v11_d2">
+    <g class="tx-title"><text class="title" x="892" y="1506" fill="black">Deposit 2 (depth=2, last="Deposit 1")</text></g>
+    <g class="tx-body">
+      <rect class="tx-box" x="892" y="1512" width="440" height="84" fill="none" stroke="black" stroke-width="1"/>
+      <g class="tx-inputs">
+        <g class="input" data-title=""><rect x="908" y="1522" width="160" height="28" fill="none" stroke="black" stroke-width="1"/></g>
+        <g class="input" data-title="Deposit"><rect x="908" y="1558" width="160" height="28" fill="none" stroke="black" stroke-width="1"/><text x="916" y="1577" text-anchor="start" fill="black">Deposit</text><text class="amount" x="1060" y="1577" text-anchor="end" fill="black">20123 sat</text></g>
+      </g>
+      <g class="tx-outputs">
+        <g class="output" data-title="Vault Output"><rect x="1108" y="1522" width="208" height="28" fill="none" stroke="black" stroke-width="1"/><text x="1116" y="1541" text-anchor="start" fill="black">Vault Output</text><text class="amount" x="1308" y="1541" text-anchor="end" fill="black">130000 sat</text></g>
+      </g>
+    </g>
+  </g>
+  <g class="tx transaction" id="tx-withdraw_1_v12_d2">
+    <g class="tx-title"><text class="title" x="892" y="1622" fill="black">Withdraw 1 (depth=2, last="Deposit 2")</text></g>
+    <g class="tx-body">
+      <rect class="tx-box" x="892" y="1628" width="432" height="120" fill="none" stroke="black" stroke-width="1"/>
+      <g class="tx-inputs">
+        <g class="input" data-title=""><rect x="908" y="1638" width="120" height="28" fill="none" stroke="black" stroke-width="1"/></g>
+      </g>
+      <g class="tx-outputs">
+        <g class="output" data-title="Vault Output"><rect x="1068" y="1638" width="240" height="28" fill="none" stroke="black" stroke-width="1"/><text x="1076" y="1657" text-anchor="start" fill="black">Vault Output</text><text class="amount" x="1300" y="1657" text-anchor="end" fill="black">110000 sat</text></g>
+        <g class="output" data-title="Withdrawal Output"><rect x="1068" y="1674" width="240" height="28" fill="none" stroke="black" stroke-width="1"/><text x="1076" y="1693" text-anchor="start" fill="black">Withdrawal Output</text><text class="amount" x="1300" y="1693" text-anchor="end" fill="black">10000 sat</text></g>
+        <g class="output" data-title="Anchor"><rect x="1068" y="1710" width="240" height="28" fill="none" stroke="black" stroke-width="1"/><text x="1076" y="1729" text-anchor="start" fill="black">Anchor</text><text class="amount" x="1300" y="1729" text-anchor="end" fill="black">0 sat</text></g>
+      </g>
+    </g>
+  </g>
+  <g class="tx transaction" id="tx-withdrawal_2_v12_d2">
+    <g class="tx-title"><text class="title" x="892" y="1774" fill="black">Withdraw 2 (depth=2, last="Deposit 2")</text></g>
+    <g class="tx-body">
+      <rect class="tx-box" x="892" y="1780" width="432" height="120" fill="none" stroke="black" stroke-width="1"/>
+      <g class="tx-inputs">
+        <g class="input" data-title=""><rect x="908" y="1790" width="120" height="28" fill="none" stroke="black" stroke-width="1"/></g>
+      </g>
+      <g class="tx-outputs">
+        <g class="output" data-title="Vault Output"><rect x="1068" y="1790" width="240" height="28" fill="none" stroke="black" stroke-width="1"/><text x="1076" y="1809" text-anchor="start" fill="black">Vault Output</text><text class="amount" x="1300" y="1809" text-anchor="end" fill="black">100000 sat</text></g>
+        <g class="output" data-title="Withdrawal Output"><rect x="1068" y="1826" width="240" height="28" fill="none" stroke="black" stroke-width="1"/><text x="1076" y="1845" text-anchor="start" fill="black">Withdrawal Output</text><text class="amount" x="1300" y="1845" text-anchor="end" fill="black">20000 sat</text></g>
+        <g class="output" data-title="Anchor"><rect x="1068" y="1862" width="240" height="28" fill="none" stroke="black" stroke-width="1"/><text x="1076" y="1881" text-anchor="start" fill="black">Anchor</text><text class="amount" x="1300" y="1881" text-anchor="end" fill="black">0 sat</text></g>
+      </g>
+    </g>
+  </g>
+  <g class="tx transaction" id="tx-deposit_1_v12_d2">
+    <g class="tx-title"><text class="title" x="892" y="1926" fill="black">Deposit 1 (depth=2, last="Deposit 2")</text></g>
+    <g class="tx-body">
+      <rect class="tx-box" x="892" y="1932" width="440" height="84" fill="none" stroke="black" stroke-width="1"/>
+      <g class="tx-inputs">
+        <g class="input" data-title=""><rect x="908" y="1942" width="160" height="28" fill="none" stroke="black" stroke-width="1"/></g>
+        <g class="input" data-title="Deposit"><rect x="908" y="1978" width="160" height="28" fill="none" stroke="black" stroke-width="1"/><text x="916" y="1997" text-anchor="start" fill="black">Deposit</text><text class="amount" x="1060" y="1997" text-anchor="end" fill="black">10123 sat</text></g>
+      </g>
+      <g class="tx-outputs">
+        <g class="output" data-title="Vault Output"><rect x="1108" y="1942" width="208" height="28" fill="none" stroke="black" stroke-width="1"/><text x="1116" y="1961" text-anchor="start" fill="black">Vault Output</text><text class="amount" x="1308" y="1961" text-anchor="end" fill="black">130000 sat</text></g>
+      </g>
+    </g>
+  </g>
+  <g class="tx transaction" id="tx-deposit_2_v12_d2">
+    <g class="tx-title"><text class="title" x="892" y="2042" fill="black">Deposit 2 (depth=2, last="Deposit 2")</text></g>
+    <g class="tx-body">
+      <rect class="tx-box" x="892" y="2048" width="440" height="84" fill="none" stroke="black" stroke-width="1"/>
+      <g class="tx-inputs">
+        <g class="input" data-title=""><rect x="908" y="2058" width="160" height="28" fill="none" stroke="black" stroke-width="1"/></g>
+        <g class="input" data-title="Deposit"><rect x="908" y="2094" width="160" height="28" fill="none" stroke="black" stroke-width="1"/><text x="916" y="2113" text-anchor="start" fill="black">Deposit</text><text class="amount" x="1060" y="2113" text-anchor="end" fill="black">20123 sat</text></g>
+      </g>
+      <g class="tx-outputs">
+        <g class="output" data-title="Vault Output"><rect x="1108" y="2058" width="208" height="28" fill="none" stroke="black" stroke-width="1"/><text x="1116" y="2077" text-anchor="start" fill="black">Vault Output</text><text class="amount" x="1308" y="2077" text-anchor="end" fill="black">140000 sat</text></g>
+      </g>
+    </g>
+  </g>
+
+</svg>

--- a/docs/diagrams/style.css
+++ b/docs/diagrams/style.css
@@ -1,0 +1,22 @@
+svg {
+	font-family: sans-serif;
+}
+
+.title {
+	font-weight: 800;
+}
+
+.transaction rect {
+	rx: 6px;
+	ry: 6px;
+	stroke-width: 2px;
+}
+
+.spend {
+	stroke-width: 2px;
+}
+
+.spend.candidate {
+	stroke: grey;
+	stroke-dasharray: 8px, 8px;
+}

--- a/docs/diagrams/withdrawal.json
+++ b/docs/diagrams/withdrawal.json
@@ -1,0 +1,123 @@
+{
+  "transactions": [
+    {
+	  "title": "Withdraw",
+      "id": "withdrawal",
+      "status": "candidate",
+      "outputs": [
+		  {
+			  "title": "Vault Output",
+			  "amount_sat": 90000
+		  },
+		  {
+			  "title": "Withdrawal Output",
+			  "amount_sat": 10000
+		  },
+		  {
+			  "title": "Anchor",
+			  "amount_sat": 0
+		  }
+	  ]
+    },
+    {
+	  "title": "Spend Withdrawal",
+      "id": "withdrawal_1_spend",
+      "status": "candidate",
+      "inputs": [
+		  {
+			  "spends": "withdrawal:1",
+			  "sequence": {
+				  "height": 3
+			  },
+			  "satisfaction": {
+				  "description": "and(hot(pk), csv(delay))"
+			  }
+		  }
+	  ],
+      "outputs": [
+		  {
+			  "title": "Spend",
+			  "amount_sat": 10000
+		  }
+	  ]
+    },
+    {
+	  "title": "Recover Vault",
+      "id": "recover_vault",
+      "status": "candidate",
+      "inputs": [
+		  {
+			  "spends": "withdrawal:0",
+			  "satisfaction": {
+				  "description": "and(pk(hot), ctv(\"Recover Vault\"))"
+			  }
+		  }
+	  ],
+      "outputs": [
+		  {
+			  "title": "Recovery Output",
+			  "description": "Only spendable by cold key",
+			  "amount_sat": 90000
+		  },
+		  {
+			  "title": "Anchor",
+			  "amount_sat": 0
+		  }
+	  ]
+    },
+    {
+	  "title": "Recover Withdrawal",
+      "id": "recover_withdrawal",
+      "status": "candidate",
+      "inputs": [
+		  {
+			  "spends": "withdrawal:1",
+			  "satisfaction": {
+				  "description": "and(pk(hot), ctv(\"Recover Withdrawal\"))"
+			  }
+		  }
+	  ],
+      "outputs": [
+		  {
+			  "title": "Recovery Output",
+			  "description": "Only spendable by cold key",
+			  "amount_sat": 10000
+		  },
+		  {
+			  "title": "Anchor",
+			  "amount_sat": 0
+		  }
+	  ]
+    },
+    {
+	  "title": "Recover Both",
+      "id": "recovery",
+      "status": "candidate",
+      "inputs": [
+		  {
+			  "spends": "withdrawal:0",
+			  "satisfaction": {
+				  "description": "and(pk(hot), ctv(\"Recover Both\"))"
+			  }
+		  },
+		  {
+			  "spends": "withdrawal:1",
+			  "satisfaction": {
+				  "description": "and(pk(hot), ctv(\"Recover Both\"))"
+			  }
+		  }
+	  ],
+      "outputs": [
+		  {
+			  "title": "Recovery Output",
+			  "description": "Only spendable by cold key",
+			  "amount_sat": 100000
+		  },
+		  {
+			  "title": "Anchor",
+			  "amount_sat": 0
+		  }
+	  ]
+    }
+  ]
+}

--- a/docs/diagrams/withdrawal.svg
+++ b/docs/diagrams/withdrawal.svg
@@ -1,0 +1,113 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg xmlns="http://www.w3.org/2000/svg" version="1.1" width="1348" height="448">
+  <metadata>txviz (docs/diagrams/withdrawal.json)</metadata>
+  <style>svg {
+	font-family: sans-serif;
+}
+
+.title {
+	font-weight: 800;
+}
+
+.transaction rect {
+	rx: 6px;
+	ry: 6px;
+	stroke-width: 2px;
+}
+
+.spend {
+	stroke-width: 2px;
+}
+
+.spend.candidate {
+	stroke: grey;
+	stroke-dasharray: 8px, 8px;
+}
+</style>
+  <rect class="diagram-background" x="0" y="0" width="1348" height="448" fill="#FFFFFF"/>
+  <g class="spend-links" fill="none" stroke="black" stroke-width="1">
+    <path class="spend-link spend" d="M 436 312 C 462.4 312, 497.6 178, 524 178"/>
+    <path class="spend-link spend" d="M 812 178 C 838.4 178, 873.6 44, 900 44"/>
+    <path class="spend-link spend" d="M 436 312 C 463.6 312, 500.4 236, 528 236"/>
+    <path class="spend-link spend" d="M 808 236 C 835.6 236, 872.4 160, 900 160"/>
+    <path class="spend-link spend" d="M 436 348 C 463.6 348, 500.4 272, 528 272"/>
+    <path class="spend-link spend" d="M 808 272 C 835.6 272, 872.4 196, 900 196"/>
+    <path class="spend-link spend" d="M 436 348 C 474.4 348, 525.6 312, 564 312"/>
+    <path class="spend-link spend" d="M 772 312 C 810.4 312, 861.6 276, 900 276"/>
+    <path class="spend-link spend" d="M 436 348 C 473.2 348, 522.8 352, 560 352"/>
+    <path class="spend-link spend" d="M 776 352 C 813.2 352, 862.8 356, 900 356"/>
+  </g>
+  <g class="spend-descriptions">
+    <g class="spend-description"><rect x="524" y="164" width="288" height="28" fill="white" stroke="black" stroke-width="1"/><text x="668" y="183" text-anchor="middle" fill="black">and(pk(hot), ctv("Recover Vault"))</text></g>
+    <g class="spend-description"><rect x="528" y="222" width="280" height="28" fill="white" stroke="black" stroke-width="1"/><text x="668" y="241" text-anchor="middle" fill="black">and(pk(hot), ctv("Recover Both"))</text></g>
+    <g class="spend-description"><rect x="528" y="258" width="280" height="28" fill="white" stroke="black" stroke-width="1"/><text x="668" y="277" text-anchor="middle" fill="black">and(pk(hot), ctv("Recover Both"))</text></g>
+    <g class="spend-description"><rect x="564" y="298" width="208" height="28" fill="white" stroke="black" stroke-width="1"/><text x="668" y="317" text-anchor="middle" fill="black">and(hot(pk), csv(delay))</text></g>
+    <g class="spend-description"><rect x="560" y="330" width="216" height="44" fill="white" stroke="black" stroke-width="1"/><text x="668" y="349" text-anchor="middle" fill="black">and(pk(hot), ctv("Recover</text><text x="668" y="365" text-anchor="middle" fill="black">Withdrawal"))</text></g>
+  </g>
+  <g class="tx transaction" id="tx-withdrawal">
+    <g class="tx-title"><text class="title" x="20" y="282" fill="black">Withdraw</text></g>
+    <g class="tx-body">
+      <rect class="tx-box" x="20" y="288" width="432" height="120" fill="none" stroke="black" stroke-width="1"/>
+      <g class="tx-inputs">
+      </g>
+      <g class="tx-outputs">
+        <g class="output" data-title="Vault Output"><rect x="196" y="298" width="240" height="28" fill="none" stroke="black" stroke-width="1"/><text x="204" y="317" text-anchor="start" fill="black">Vault Output</text><text class="amount" x="428" y="317" text-anchor="end" fill="black">90000 sat</text></g>
+        <g class="output" data-title="Withdrawal Output"><rect x="196" y="334" width="240" height="28" fill="none" stroke="black" stroke-width="1"/><text x="204" y="353" text-anchor="start" fill="black">Withdrawal Output</text><text class="amount" x="428" y="353" text-anchor="end" fill="black">10000 sat</text></g>
+        <g class="output" data-title="Anchor"><rect x="196" y="370" width="240" height="28" fill="none" stroke="black" stroke-width="1"/><text x="204" y="389" text-anchor="start" fill="black">Anchor</text><text class="amount" x="428" y="389" text-anchor="end" fill="black">0 sat</text></g>
+      </g>
+    </g>
+  </g>
+  <g class="tx transaction" id="tx-recover_vault">
+    <g class="tx-title"><text class="title" x="884" y="14" fill="black">Recover Vault</text></g>
+    <g class="tx-body">
+      <rect class="tx-box" x="884" y="20" width="416" height="84" fill="none" stroke="black" stroke-width="1"/>
+      <g class="tx-inputs">
+        <g class="input" data-title=""><rect x="900" y="30" width="120" height="28" fill="none" stroke="black" stroke-width="1"/></g>
+      </g>
+      <g class="tx-outputs">
+        <g class="output" data-title="Recovery Output"><rect x="1060" y="30" width="224" height="28" fill="none" stroke="black" stroke-width="1"/><text x="1068" y="49" text-anchor="start" fill="black">Recovery Output</text><text class="amount" x="1276" y="49" text-anchor="end" fill="black">90000 sat</text></g>
+        <g class="output" data-title="Anchor"><rect x="1060" y="66" width="224" height="28" fill="none" stroke="black" stroke-width="1"/><text x="1068" y="85" text-anchor="start" fill="black">Anchor</text><text class="amount" x="1276" y="85" text-anchor="end" fill="black">0 sat</text></g>
+      </g>
+    </g>
+  </g>
+  <g class="tx transaction" id="tx-recovery">
+    <g class="tx-title"><text class="title" x="884" y="130" fill="black">Recover Both</text></g>
+    <g class="tx-body">
+      <rect class="tx-box" x="884" y="136" width="424" height="84" fill="none" stroke="black" stroke-width="1"/>
+      <g class="tx-inputs">
+        <g class="input" data-title=""><rect x="900" y="146" width="120" height="28" fill="none" stroke="black" stroke-width="1"/></g>
+        <g class="input" data-title=""><rect x="900" y="182" width="120" height="28" fill="none" stroke="black" stroke-width="1"/></g>
+      </g>
+      <g class="tx-outputs">
+        <g class="output" data-title="Recovery Output"><rect x="1060" y="146" width="232" height="28" fill="none" stroke="black" stroke-width="1"/><text x="1068" y="165" text-anchor="start" fill="black">Recovery Output</text><text class="amount" x="1284" y="165" text-anchor="end" fill="black">100000 sat</text></g>
+        <g class="output" data-title="Anchor"><rect x="1060" y="182" width="232" height="28" fill="none" stroke="black" stroke-width="1"/><text x="1068" y="201" text-anchor="start" fill="black">Anchor</text><text class="amount" x="1284" y="201" text-anchor="end" fill="black">0 sat</text></g>
+      </g>
+    </g>
+  </g>
+  <g class="tx transaction" id="tx-withdrawal_1_spend">
+    <g class="tx-title"><text class="title" x="884" y="246" fill="black">Spend Withdrawal</text></g>
+    <g class="tx-body">
+      <rect class="tx-box" x="884" y="252" width="360" height="48" fill="none" stroke="black" stroke-width="1"/>
+      <g class="tx-inputs">
+        <g class="input" data-title=""><rect x="900" y="262" width="120" height="28" fill="none" stroke="black" stroke-width="1"/><text class="sequence" x="908" y="281" text-anchor="start" fill="black">after 3 blocks</text></g>
+      </g>
+      <g class="tx-outputs">
+        <g class="output" data-title="Spend"><rect x="1084" y="262" width="144" height="28" fill="none" stroke="black" stroke-width="1"/><text x="1092" y="281" text-anchor="start" fill="black">Spend</text><text class="amount" x="1220" y="281" text-anchor="end" fill="black">10000 sat</text></g>
+      </g>
+    </g>
+  </g>
+  <g class="tx transaction" id="tx-recover_withdrawal">
+    <g class="tx-title"><text class="title" x="884" y="326" fill="black">Recover Withdrawal</text></g>
+    <g class="tx-body">
+      <rect class="tx-box" x="884" y="332" width="416" height="84" fill="none" stroke="black" stroke-width="1"/>
+      <g class="tx-inputs">
+        <g class="input" data-title=""><rect x="900" y="342" width="120" height="28" fill="none" stroke="black" stroke-width="1"/></g>
+      </g>
+      <g class="tx-outputs">
+        <g class="output" data-title="Recovery Output"><rect x="1060" y="342" width="224" height="28" fill="none" stroke="black" stroke-width="1"/><text x="1068" y="361" text-anchor="start" fill="black">Recovery Output</text><text class="amount" x="1276" y="361" text-anchor="end" fill="black">10000 sat</text></g>
+        <g class="output" data-title="Anchor"><rect x="1060" y="378" width="224" height="28" fill="none" stroke="black" stroke-width="1"/><text x="1068" y="397" text-anchor="start" fill="black">Anchor</text><text class="amount" x="1276" y="397" text-anchor="end" fill="black">0 sat</text></g>
+      </g>
+    </g>
+  </g>
+
+</svg>

--- a/docs/protocol.md
+++ b/docs/protocol.md
@@ -1,96 +1,218 @@
-# MCCV Protocol
+# MCCV Protocol Notes (Draft)
 
-> [!WARNING]
-> This document is severely out of date and in the process of a significant rewrite!
-> In its current state it is still useful for understanding the vault, but some of the details are likely wrong.
+> [!NOTE]
+> This document is somewhat of a work in progress.
+> It covers most of the critical design components, and is now up-to-date, but it could use more revision than it's gotten.
 
-Every vault state is represented by a transaction with a depth, a value, and either a withdrawal or deposit amount.
-For simplicity we'll ignore timelock and input count for just depth and value.
-This illustration shows a vault capable of 3 vault operations (plus one initial deposit), and 3 possible values.
-Values are represented as integers between 1 and a finite limit, and represent multiples of some other denomination, like 1,000,000 sats.
+## Goals
 
+This vault protocol was designed to prevent catastrophic theft of funds even if ones keys have been compromised.
 
-    +Time ------------------->
-    V_0,1  V_1,1  V_2,1  V_3,1 +Vault Value
-    V_0,2  V_1,2  V_2,2  V_3,2   |
-    V_0,3  V_1,3  V_2,3  V_3,3   V
+## Threat Model
 
-If the user deposits a value of 2, then the first vault transaction is `V_0,2`
-with a value of 2.
-If the user then withdraws 1, the second transaction becomes `V_1,1` with a
-value of 1.
-Then, if the user deposits another 2, the third transaction becomes `V_2,3` with
-a value of 3.
-Finally, if the user withdaws 1, the final transaction will be `V_3,2` with a
-final value of 2. 
-The following sequence of transactions would be made on-chain.
+## Intended Security Properties
 
-    V_0,2 -> V_1,1 -> V_2,3 -> V_3,2
+MCCV is designed to mitigate theft of funds caused by compromise of the hot wallet.
 
-| Transaction | Depth | Value | Withdrawal/Deposit Amount | Timelock | Next Timelock |
-|-------------|-------|-------|---------------------------|----------|---------------|
-| V_0,2       | 0     | 2     | Deposit 2                 | 0        | 0             |
-| V_1,1       | 1     | 1     | Withdraw 1                | 0        | T             |
-| V_2,3       | 2     | 3     | Deposit 2                 | T        | 0             |
-| V_3,2       | 3     | 2     | Withdraw 1                | 0        | T             |
+An attacker who gains access to the hot wallet keys should be unable to immediately steal the full vault balance.
+Instead, withdrawals are delayed and rate limited.
+Rate limiting provides the user or a delegated watchtower time to detect unauthorized withdrawals and sweep the vault to the recovery key.
 
-# Transactions
+The protocol's consensus-enforced rate limiting also mitigates the scenario where the user or delegated watchtowers fail to detect unauthorized withdrawals in a timely fashion.
+This rate limiting also mitigates losses if they fail to get the recovery transaction confirmed in a timely fashion.
 
-## Vault Prepare Transaction
+## Security Assumptions
 
-Also known as the "shape transaction" in the code.
+The security of this system depends on several critical assumptions:
 
-                              Randomized TxOut Order
-            +------------+
-    In 0 -> |            | -> Vault Deposit
-    In 1 -> |            | -> Change
-     ...    |            |
-    In N -> |            |
-            +------------+
+* The recovery key must remain uncompromised.
+* The user or a delegated watchtower must monitor the blockchain and respond to unauthorized withdrawals during the challenge period.
+* Recovery transactions must be able to confirm on-chain before the withdrawal timelock expires in order to fully prevent all unauthorized withdrawals.
+  * This includes the ability of the user or a delegated watchtower to independently provide fees for the recovery transaction(s).
+* The precomputed vault graph must be generated correctly and verified by the user.
+* Bitcoin consensus rules, including `OP_CHECKTEMPLATEVERIFY`, must behave as expected.
 
-### Vault Deposit Output
+## Bitcoin Ecosystem Assumptions
 
-CTV into Vault
+* Consensus enforcing BIP-119 `OP_CHECKTEMPLATEVERIFY`
+* Policy supporting Ephemeral Anchors - Required for propagation of zero-fee Deposit Shape, Withdrawal, and Recovery transactions
+* Policy supporting Package Relay - Required for children to pay for the above transactions
 
-OR
+## Out of Scope
 
-Timelocked spendable by hot key (do we even want this? costs 32 wu to have this)
+MCCV is not intended to protect against:
 
-## Deposit Transaction
+* compromise of the recovery key
+* malicious or buggy vault generation software
+* prolonged loss of blockchain monitoring
+* denial-of-service attacks preventing recovery transaction confirmation
+* physical coercion attacks
+* Bitcoin consensus failures
 
-                     +------------+
-    [ Vault ]     -> |            | -> Vault
-    Vault Deposit -> |            | -> Anchor Output
-                     +------------+
+## Vault Structure
 
-### Vault Input
+Vaults are deterministically derived from a small set of parameters:
 
-(Optional) input carrying prevoius vault balance.
-Won't be present when previous vault value is 0.
+* hot xpub - The xpub from which all hot keys are derived.
+These keys authorize deposits, withdrawals, and sweeps to recovery.
+* cold xpub - The xpub from which all cold keys are derived.
+The cold keys are the recovery keys.
+The user must keep the secret key material backing the cold xpub secret to maintain the security of the vault.
+* `scale` - the base deposit and withdrawal increment. Every operation on the vault is in multiples of this number of satoshis.
+* `delay` - blocks of delay per increment withdrawn
+* `max-withdrawal` - maximum amount that may be withdrawn at once
+* `max-deposit` - maximum amount that may be deposited at once
+* `max-depth` - number of operations the vault can support (the depth of the DAG)
 
-### Vault Output
+The vault itself is a precomputed directed acyclic graph of transaction outputs, enforced by consensus by `OP_CHECKTEMPLATEVERIFY`.
+Every possible state and state transition is enumerated and committed to by the `OP_CHECKTEMPLATEVERIFY` hashes.
+Each transaction has either a vault output, a withdrawal output, or both.
 
-CTV for either withdrawal or deposit
+Transactions are ordered into "generation"s, every transaction within a generation is considered to have the same "depth".
+Depth is the number of vault operations that have been performed on this vault prior to this transaction (within the history of this vault UTXO).
+Depth never reflects vault operations on the vault done with a separate UTXO.
+Vaults are intended to be a single continuous history.
+If the user wishes to create an additional vault with otherwise identical parameters, the account index should be incremented.
+Reusing identical vault parameters with multiple UTXOs directly links independent vaults together, and risks key reuse.
+Furthermore, the current iteration of the software implementation does not adequately handle this scenario if done intentionally.
 
-## Withdrawal Transaction
+A vault output represents a vault in a particular state, with a balance, and the two previous vault operations (deposit or withdrawal) and implicitly a depth (the number of previous vault operations performed on this vault).
+The two previous vault operations are necessary because the previous operation defines the shape of the current transaction, and the operation before that defines the `nSequence` relative timelock.
+The current balance is not expressed in satoshis, but instead it is an integer that must be scaled by `scale` to get the actual value of the vault output.
+The vault output's value is always `scale * balance`.
 
-             +------------+
-    Vault -> |            | -> [ Vault ]
-             |            | -> Unvault
-             |            | -> Anchor Output
-             +------------+
+The vault output has taproot script paths for each potential subsequent vault operation, except for the last vault output, which can only be spent by the recovery keys.
+The potential vault operations are: deposit some amount, withdraw some amount, sweep to recovery with a withdrawal output, sweep to recovery by itself.
+Withdrawal outputs have three operations available by the script path: sweep to recovery with a vault output, sweep to recovery by itself, and spend once mature.
+Vault and Withdrawal outputs are always spendable by the cold keys via the taproot key path.
 
-### Unvault Output
+> [!NOTE]
+> `log_2( max-withdrawal + max-deposit + 2 )` must be less than 101 for Deposit transactions to remain within the size limits for TRUC transactions.
+> This is only noted for completeness, as practical vaults are comfortably under 8.
 
-Either
+![Overview Diagram](diagrams/overview.svg)
 
-Spendable by hot wallet after timelock
+## Performance
 
-or
+As suggested by the overview diagram, this scheme is quite computationally intensive.
+Every transaction and transition between states must be computed and the transactions' `OP_CHECKTEMPLATEVERIFY` hash calculated.
+Until up-to-date benchmarks are produced, the general performance characteristics of the vault on commodity hardware is as follows: computing vaults with hundreds of available operations can be accomplished in tens of minutes, depending on the other parameters.
 
-Clawback to cold wallet
+## Deposit Operations
 
-### Vault Output
+![Deposit Diagram](diagrams/deposit.svg)
 
-(Optional) Change for the vault.
-Same as deposit output except it carries a timelock as well.
+Deposits are always made in multiples of the vault's `scale`, so a vault with a scale of 10,000 sats might accept deposits of 10,000 sats, 20,000 sats, 30,000 sats and possibly more.
+The maximum amount that can be deposited in a single deposit transaction is governed by the `max-deposit` parameter.
+
+Deposits are made in a two step process.
+First, the hot wallet creates a Deposit Shape transaction, which is a zero fee transaction with an output valued at the deposit amount + desired fee.
+Because the vault only permits transactions from a finite precomputed set, the actual vault transaction requires an input of the appropriate size, which is what the Deposit Shape transaction provides.
+
+The fee contribution is represented in the above diagram by the "Deposit Shape" transactions contributing 10,123 sats instead of just 10,000, with the 123 serving as a fee for the combined package.
+Then, the deposit transaction is created, spending the previous vault output (if present) with the new deposit amount, creating a new vault output.
+The desired fee is paid by the child deposit transaction, since the input to the deposit transaction is `vault_current + deposit_amount + desired_fee` and the output from the deposit transaction is `vault_current + deposit_amount`.
+
+There are two versions of the vault transaction: one with a relative timelock, and one without.
+The vault output following a deposit transaction does not have a relative timelock.
+The vault outputs on withdrawal transactions always commit to vault transactions with a relative timelock equal to the relative timelock on the withdrawal output.
+This ensures that an attacker can't just bypass the overall rate limit by issuing several withdrawals.
+
+## Withdrawal Operations
+
+![Withdrawal Diagram](diagrams/withdrawal.svg)
+
+Like [deposits](#deposit-operations), withdrawals are always made in multiples of the vault's `scale` up to a maximum defined by the vault's `max-withdrawal`.
+
+Withdrawals are also achieved by a two step process.
+The first step in the process is to create the withdrawal transaction.
+Because the vault can only permit transactions from a finite precomputed set, the withdrawals must first move the withdrawn funds into an output with a fixed value and a fixed hot key.
+
+The withdrawal transaction includes a timelock which is derived from the amount withdrawn by taking the number of increments withdrawn and multiplying it by the delay parameter.
+The withdrawal output on the withdrawal transaction enforces the delay with a CSV, and the vault output (if present) enforces the delay indirectly with CTV which ensures the next vault transaction has the correct `nSequence`.
+This withdrawal transaction will have a withdrawal output, an anchor output, and if there is a remaining vault balance, a vault output.
+
+Before the withdrawal has matured, it can be [swept to the recovery key](#recovery-operations) by the user or their watchtowers.
+Both the withdrawal output, and the vault output, if present, have spending paths to [sweep them to the recovery keys](#recovery-operations), both alone and together if applicable.
+After it has matured, it can then be spent by the hot keys to the desired destination.
+This means that the withdrawal output has three script path spends: hot key spend after maturity, sweep withdrawal output to recovery alone, and if there is a remaining vault balance, sweep withdrawal and vault balance together to recovery.
+
+## Recovery Operations
+
+Recovery transactions allow the user or their watchtower to sweep the vault and any pending withdrawals to a recovery key.
+
+There are four variations on the recovery transaction:
+- Spending only the vault output of a [deposit](#deposit-operations) transaction
+- Spending only the vault output of a [withdrawal](#withdrawal-operations) transaction (ignoring the withdrawal output)
+- Spending the vault and withdrawal outputs together of a withdrawal transaction
+- Spending only the withdrawal output of a withdrawal transaction (ignoring the vault output, or when the vault output is not present because the withdrawal empties the vault)
+
+Spending a vault output with a recovery transaction ends the vault.
+
+The recovery transaction always has two outputs, an output spendable by a recovery key, and an anchor output.
+Recovery keys are derived from the cold xpub, every level of depth has a unique recovery key.
+
+The anchor output is used so that a child transaction can pay for the recovery transaction's fees.
+
+## Future Improvements
+
+### Delegated Recovery Key
+
+Probably the biggest omission from the current design is that there's no way for a delegated agent to sweep coins to the recovery key without also giving them the ability to initiate withdrawals.
+A simple key delegation from the hot key to a delegate key using `OP_CHECKSIGFROMSTACK` in a dedicated tap leaf would accomplish this.
+This would enable users to delegate only the authority to initiate recovery to watchtower services.
+This is a pretty simple change, and I'd like to get to it as quickly as I can.
+
+### Standalone Watchtower
+
+This is probably the biggest omission from the current *implementation*, I expect to do this in the near term.
+You can manually perform watchtower functions, enough to demonstrate the functionality of the protocol, but it'd be nice to have something automated.
+It will be fairly easy to do, I just need to move on to other work ASAP right now.
+
+### Sweep to delegate
+
+I don't have an exact design for this in mind, but the idea is to provide a plausible backup in case of lost keys.
+A company particularly in a collaborative custody setup could have an option to sweep the vault into their custody.
+This would be encumbered with a very long timelock (on the order of months) during which the user can sweep to their recovery address (the same as if an unauthorized withdrawal was initiated).
+
+### Caching
+
+Large vaults can take minutes to compute, and right now the MCCV recalculates the entire vault repeatedly.
+The simplest thing to do is cache every N generations on disk, this brings the computation time back into a reasonable order at the expense of disk space.
+
+### Optimization
+
+There are plenty of micro and macro optimizations still left.
+On the macro side, the vault code doesn't universally use the `Context` object for in-memory cached computations, that's an easy win.
+On the micro side, converting the CTV computation code from building a `rust-bitcoin` `Transaction` to streaming it into a hash is a substantial win in [related benchmarks I've done](https://github.com/Ademan/rust-bip119-bench?tab=readme-ov-file#results).
+
+### STARK Proofs
+
+I want to call special attention to this idea.
+The biggest problem with this protocol, in my opinion, is that it is too CPU intensive to run on a hardware wallet, but initial vault setup must be performed on a trusted device.
+Resolving this tension would be tremendously valuable.
+I have to admit I don't know how feasible it is, but if a hardware wallet could *verify* that the vault was generated correctly it would provide a satisfying resolution.
+This allows the heavy computation to be performed on powerful consumer hardware, but trust to reside in the hardware wallet.
+With that, I think there is a very compelling user story that is otherwise considerably weaker.
+Of course, it still remains to be seen if this approach is feasible.
+The verifier code must be compact enough to fit on a hardware wallet along side existing wallet functionality, and be performant enough for vault verification to be acceptably quick.
+Likewise, after computing a large vault, generating the proof must be reasonably fast as well.
+
+### Generalizing
+
+MCCV demonstrates a style of contract that can be built using `OP_CHECKTEMPLATEVERIFY`, but a large portion of the code can be reused for other contracts.
+I began some work on generalizing it, but there's a lot more left to do.
+It's also very worth exploring if investing time into optimizing [sapio](https://learn.sapio-lang.org/) is a better use of time.
+Most of `MCCV`s speed came from exploiting the structure of the vault to facilitate parallelism and those benefits could be lost if I try to make this software too generic.
+
+### GPU Acceleration
+
+With some work, GPU acceleration could substantially improve the time it takes to generate the vault context.
+This could definitely be valuable in making larger vaults practical to compute, but a much higher priority in my opinion, is to figure out how to make vault generation practical to either generate, or verify on hardware wallets.
+
+### `OP_TEMPLATEHASH`
+
+Templatehash is a drop-in replacement for `OP_CHECKTEMPLATEVERIFY` for the purposes of MCCV.
+I'd like to make the covenant opcode a feature flag so that either can be used, but I want to address [Optimization](#optimization) first.
+The streaming hashing has a deep impact on how MCCV interacts with both `OP_CHECKTEMPLATEVERIFY` and `OP_TEMPLATEHASH` so I'd like to nail that down *first*.
+On the other hand, it also would take barely an afternoon to swap in `OP_TEMPLATEHASH` the way `OP_CHECKTEMPLATEVERIFY` is currently used, so maybe I'll do it sooner.


### PR DESCRIPTION
This change replaces the original protocol document with something more fleshed out, it tries to more thoroughly cover the design, and includes diagrams generated by [txviz](https://github.com/Ademan/txviz/). The diagrams are Ok but I want to iterate on txviz, the layout code is pretty rough.

* txviz is 100% vibe coded with very minimal review on changes. I suspect to get it where I want it I'll have to really dig in myself, but for the time being this is one of the few work items I felt comfortable completely delegating to an LLM.