### PR TITLE
Make recovery coins only spendable by cold keys

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,20 @@
+# Changelog
+
+## Unreleased
+
+### Fixed
+
+Vault recovery coins are now locked by the correct (cold) keys.
+
+### Security
+
+Vaults created using v0.1.0 software are insecure.
+They use the wrong key, the hot key, to lock funds which were swept to the recovery location, defeating the purpose of the sweep.
+
+### Compatibility
+
+Vaults created using v0.1.0 need to be drained to another wallet, using v0.1.0 software, then recreated using >v0.1.0 software.
+
+## 0.1.0 - 2026-05-28
+
+Initial release

--- a/data/migrations/0002-vault-version.sql
+++ b/data/migrations/0002-vault-version.sql
@@ -1,0 +1,2 @@
+alter table mccv_vault
+add column version integer;

--- a/src/main.rs
+++ b/src/main.rs
@@ -455,6 +455,12 @@ impl VaultSystem {
 
         let (vault, vault_changelog) = storage.vault_storage
             .load(secp, vault_id)
+            .inspect_err(|e| {
+                match e {
+                    mccv::vault_storage::LoadError::VaultMustBeRecreated => eprintln!("E: {e}"),
+                    _ => {}
+                }
+            })
             .expect("load vault");
 
         Self {

--- a/src/transaction.rs
+++ b/src/transaction.rs
@@ -768,7 +768,7 @@ impl WithdrawalOutputSpendInfo {
     pub fn from_parameters<C: Verification>(secp: &Secp256k1<C>, parameters: &VaultParameters, depth: Depth, timelock: relative::LockTime, vault_amount: VaultAmount, withdrawal_amount: VaultAmount) -> Self {
         let master_pubkey = parameters.master_key(secp, depth);
         let hot_pubkey = parameters.hot_key(secp, depth);
-        let recovery_key = parameters.hot_key(secp, depth + 1);
+        let recovery_key = parameters.recovery_key(secp, depth + 1);
 
         let timelocked_withdrawal_script = TimelockedSpend { pubkey: hot_pubkey, timelock };
         let timelocked_withdrawal_script = timelocked_withdrawal_script.to_scriptbuf();

--- a/src/vault.rs
+++ b/src/vault.rs
@@ -512,12 +512,26 @@ impl VaultParameters {
     // Hot key can trigger recovery. This is fine because if the hot key is compromised your (hot) funds
     // are already at risk, being griefed by your funds being sent to the cold key is the
     // best case scenario.
-    fn recovery_key<C: Verification>(&self, secp: &Secp256k1<C>, depth: Depth) -> XOnlyPublicKey {
+    /// Generate the key that may sweep funds to recovery at a certain depth
+    /// This is currently the same as the hot key at the same depth.
+    fn trigger_recovery_key<C: Verification>(&self, secp: &Secp256k1<C>, depth: Depth) -> XOnlyPublicKey {
         let path = [
             ChildNumber::from_normal_idx(depth as u32).expect("sane child number")
         ];
 
         let xpub = self.hot_xpub.derive_pub(secp, &path)
+            .expect("recovery key derivation");
+
+        xpub.to_x_only_pub()
+    }
+
+    /// Generate the key that may access funds swept to recovery at a certain depth
+    pub(crate) fn recovery_key<C: Verification>(&self, secp: &Secp256k1<C>, depth: Depth) -> XOnlyPublicKey {
+        let path = [
+            ChildNumber::from_normal_idx(depth as u32).expect("sane child number")
+        ];
+
+        let xpub = self.cold_xpub.derive_pub(secp, &path)
             .expect("recovery key derivation");
 
         xpub.to_x_only_pub()
@@ -565,9 +579,9 @@ impl VaultParameters {
             input.push(dummy_input(relative::LockTime::ZERO));
         }
 
-        let key = self.recovery_key(secp, depth);
+        let recovery_key = self.recovery_key(secp, depth);
 
-        let script_pubkey = ScriptBuf::new_p2tr(secp, key, None);
+        let script_pubkey = ScriptBuf::new_p2tr(secp, recovery_key, None);
 
         let recovered_value = vault_amount + withdrawal_amount;
 
@@ -637,7 +651,7 @@ impl VaultParameters {
             //eprintln!("counter = {counter}");
         }
 
-        let recovery_key = self.recovery_key(secp, depth);
+        let trigger_recovery_key = self.trigger_recovery_key(secp, depth);
 
         // FIXME: we really need to get consistent about depth + 1 vs depth
         // I think the rule should be, that the transaction spending a txout with depth n is
@@ -660,7 +674,7 @@ impl VaultParameters {
                         withdrawal_amount: VaultAmount::ZERO,
                     },
                     SignedNextStateTemplate {
-                        pubkey: recovery_key,
+                        pubkey: trigger_recovery_key,
                         next_state_template_hash: get_default_template(&recovery_tx, 0),
                     },
                 )
@@ -681,7 +695,7 @@ impl VaultParameters {
                         withdrawal_amount,
                     },
                     SignedNextStateTemplate {
-                        pubkey: recovery_key,
+                        pubkey: trigger_recovery_key,
                         next_state_template_hash: get_default_template(&recovery_tx, 0),
                     },
                 )

--- a/src/vault_storage.rs
+++ b/src/vault_storage.rs
@@ -49,12 +49,42 @@ use crate::vault::{
 
 use std::str::FromStr;
 
+#[derive(PartialEq, Eq)]
+enum VaultVersion {
+    /// created by <= v0.1.0. Has recovery key bug
+    None,
+    /// Not subject to recovery bug
+    RecoveryBugFixed,
+}
+
+impl FromSql for VaultVersion {
+    fn column_result(value: rusqlite::types::ValueRef<'_>) -> rusqlite::types::FromSqlResult<Self> {
+        match value.as_i64_or_null()? {
+            None => Ok(VaultVersion::None),
+            Some(0) => Ok(VaultVersion::RecoveryBugFixed),
+            Some(x) => Err(rusqlite::types::FromSqlError::OutOfRange(x)),
+        }
+    }
+}
+
+impl ToSql for VaultVersion {
+    fn to_sql(&self) -> rusqlite::Result<ToSqlOutput<'_>> {
+        match self {
+            VaultVersion::None =>
+                Ok(ToSqlOutput::Owned(rusqlite::types::Value::Null)),
+            VaultVersion::RecoveryBugFixed =>
+                Ok(ToSqlOutput::Owned(rusqlite::types::Value::Integer(0i64))),
+        }
+    }
+}
+
 #[allow(dead_code)]
 pub static VAULT_VERSION_ID: i64 = 1;
 
 #[allow(dead_code)]
-pub static VAULT_MIGRATIONS: [(u32, &str); 1] = [
+pub static VAULT_MIGRATIONS: [(u32, &str); 2] = [
     (1, include_str!("../data/migrations/0001-initial.sql")),
+    (2, include_str!("../data/migrations/0002-vault-version.sql")),
 ];
 
 pub struct SqliteStorage {
@@ -353,6 +383,7 @@ pub enum LoadError {
     AddBlockError(AddBlockError),
     AddTransactionError(AddTransactionError<ConnectVaultTransactionError>),
     IgnoredContractTransaction(Txid),
+    VaultMustBeRecreated,
 }
 
 impl From<rusqlite::Error> for LoadError {
@@ -381,6 +412,8 @@ impl std::fmt::Display for LoadError {
             LoadError::AddBlockError(e) => write!(f, "Error adding block: {e}"),
             LoadError::AddTransactionError(e) => write!(f, "Error adding transaction {e}"),
             LoadError::IgnoredContractTransaction(txid) => write!(f, "Transaction {txid} was erroneously ignored"),
+            LoadError::VaultMustBeRecreated => write!(f, "This vault is insecure and incompatible with this version of MCCV because it was created by v0.1.0; it must be drained using v0.1.0 and recreated with a later version."),
+
         }
     }
 }
@@ -588,8 +621,9 @@ impl Storage for SqliteStorage {
                     delay_per_increment,
                     max_withdrawal_per_step,
                     max_deposit_per_step,
-                    max_depth
-                ) values ( ?, ?, ?, ?, ?, ?, ?, ?, ? )
+                    max_depth,
+                    version
+                ) values ( ?, ?, ?, ?, ?, ?, ?, ?, ?, ? )
             "#)?;
 
             insert_vault.execute(
@@ -603,6 +637,7 @@ impl Storage for SqliteStorage {
                     parameters.max_withdrawal_per_step,
                     parameters.max_deposit_per_step,
                     parameters.max_depth,
+                    VaultVersion::RecoveryBugFixed,
                 ]
             )?;
 
@@ -640,12 +675,13 @@ impl Storage for SqliteStorage {
                 delay_per_increment,
                 max_withdrawal_per_step,
                 max_deposit_per_step,
-                max_depth
+                max_depth,
+                version
             from mccv_vault
             where id = ?
         "#)?;
 
-        let parameters = parameters.query_map(
+        let (vault_version, parameters) = parameters.query_map(
             params![ id ],
             |row| {
                 let scale: VaultScale = row.get::<_, u32>(0)
@@ -657,24 +693,32 @@ impl Storage for SqliteStorage {
                 let max_withdrawal_per_step: VaultAmount = row.get(5)?;
                 let max_deposit_per_step: VaultAmount = row.get(6)?;
                 let max_depth: u32 = row.get(7)?;
+                let vault_version: VaultVersion = row.get(8)?;
 
                 Ok(
-                    VaultParameters {
-                        scale,
-                        max,
-                        cold_xpub,
-                        hot_xpub,
-                        delay_per_increment,
-                        max_withdrawal_per_step,
-                        max_deposit_per_step,
-                        max_depth,
-                    }
+                    (
+                        vault_version,
+                        VaultParameters {
+                            scale,
+                            max,
+                            cold_xpub,
+                            hot_xpub,
+                            delay_per_increment,
+                            max_withdrawal_per_step,
+                            max_deposit_per_step,
+                            max_depth,
+                        }
+                    )
                 )
             },
         )?
         .next()
         .ok_or(LoadError::NotFound)?
         .map_err(LoadError::SqliteError)?;
+
+        if vault_version != VaultVersion::RecoveryBugFixed {
+            return Err(LoadError::VaultMustBeRecreated);
+        }
 
         let mut query_blocks = transaction.prepare(r#"
             with


### PR DESCRIPTION
As of v0.1.0 recovery coins are locked not by the cold keys but by the hot keys! That defeats the purpose of sweeping to the recovery address! Very embarrassing. I think this happened when I was renaming some of the key derivation functions. Nevertheless, it needs to be fixed ASAP.

This will break v0.1.0 vaults. Signet users, if there are any, need to drain their vaults to another wallet and create a new vault.